### PR TITLE
add missing quote in example command - RScript Plugin

### DIFF
--- a/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Script.java
+++ b/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Script.java
@@ -36,7 +36,7 @@ import java.util.List;
                 "  mdy(\"06-04-2011\");",
                 "  dmy(\"04/06/2012\")",
                 "beforeCommands:",
-                "  - Rscript -e 'install.packages(\"lubridate\")"
+                "  - Rscript -e 'install.packages(\"lubridate\")'"
             }
         ),
     }


### PR DESCRIPTION

When I was looking at the documentation for RScript Plugin, I came across a missing quotation mark at the end of the command (see image below).

![image](https://github.com/kestra-io/plugin-scripts/assets/22992723/ab140f31-a1ed-455a-a96f-fd1c12e05315)

Assuming the documentation was generated from the file [‎plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Script.java](https://github.com/kestra-io/plugin-scripts/blob/70cebe911629c9c9dc4156e7b217225bcc4db827/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Script.java#L34), I made the required changes in the same file.


