### PR TITLE
fix: suppress Python warning

### DIFF
--- a/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/Script.java
+++ b/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/Script.java
@@ -150,7 +150,10 @@ public class Script extends AbstractExecScript {
         );
 
         return commands
-            .addEnv(Map.of("PYTHONUNBUFFERED", "true"))
+            .addEnv(Map.of(
+                "PYTHONUNBUFFERED", "true",
+                "PIP_ROOT_USER_ACTION", "ignore"
+            ))
             .withCommands(commandsArgs)
             .run();
     }

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
@@ -270,7 +270,10 @@ public class Commands extends AbstractExecScript {
         );
 
         return this.commands(runContext)
-            .addEnv(Map.of("PYTHONUNBUFFERED", "true"))
+            .addEnv(Map.of(
+                "PYTHONUNBUFFERED", "true",
+                "PIP_ROOT_USER_ACTION", "ignore"
+            ))
             .withCommands(commandsArgs)
             .run();
     }

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
@@ -140,7 +140,10 @@ public class Script extends AbstractExecScript {
         );
 
         return commands
-            .addEnv(Map.of("PYTHONUNBUFFERED", "true"))
+            .addEnv(Map.of(
+                "PYTHONUNBUFFERED", "true",
+                "PIP_ROOT_USER_ACTION", "ignore"
+            ))
             .withCommands(commandsArgs)
             .run();
     }


### PR DESCRIPTION
Currently, whenever you install any packages using `beforeCommands`, you'll always see this annoying warning: `WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behavior with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv`

it can be easily suppressed with an environment variable 