### PR TITLE
feat(script): add new option to fail task on first cmd with a non-zero status

### DIFF
--- a/plugin-script-julia/src/main/java/io/kestra/plugin/scripts/julia/Commands.java
+++ b/plugin-script-julia/src/main/java/io/kestra/plugin/scripts/julia/Commands.java
@@ -83,7 +83,7 @@ public class Commands extends AbstractExecScript {
     public ScriptOutput run(RunContext runContext) throws Exception {
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             this.commands
         );
 

--- a/plugin-script-julia/src/main/java/io/kestra/plugin/scripts/julia/Script.java
+++ b/plugin-script-julia/src/main/java/io/kestra/plugin/scripts/julia/Script.java
@@ -98,7 +98,7 @@ public class Script extends AbstractExecScript {
 
         List<String> commandsArgs  = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             String.join(" ", "julia", relativeScriptPath.toString())
         );
 

--- a/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/Commands.java
+++ b/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/Commands.java
@@ -80,7 +80,7 @@ public class Commands extends AbstractExecScript {
     public ScriptOutput run(RunContext runContext) throws Exception {
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             this.commands
         );
 

--- a/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/Script.java
+++ b/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/Script.java
@@ -156,7 +156,7 @@ public class Script extends AbstractExecScript {
 
         List<String> commandsArgs  = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             String.join(" ", "node", relativeScriptPath.toString())
         );
 

--- a/plugin-script-powershell/src/main/java/io/kestra/plugin/scripts/powershell/Commands.java
+++ b/plugin-script-powershell/src/main/java/io/kestra/plugin/scripts/powershell/Commands.java
@@ -88,12 +88,17 @@ public class Commands extends AbstractExecScript {
     public ScriptOutput run(RunContext runContext) throws Exception {
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             this.commands
         );
 
         return this.commands(runContext)
             .withCommands(commandsArgs)
             .run();
+    }
+
+    @Override
+    protected List<String> getExitOnErrorCommands() {
+        return List.of("$ErrorActionPreference = \"Stop\"");
     }
 }

--- a/plugin-script-powershell/src/main/java/io/kestra/plugin/scripts/powershell/Script.java
+++ b/plugin-script-powershell/src/main/java/io/kestra/plugin/scripts/powershell/Script.java
@@ -109,12 +109,17 @@ public class Script extends AbstractExecScript {
 
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             ".\\" + relativeScriptPath
         );
 
         return commands
             .withCommands(commandsArgs)
             .run();
+    }
+
+    @Override
+    protected List<String> getExitOnErrorCommands() {
+        return List.of("$ErrorActionPreference = \"Stop\"");
     }
 }

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
@@ -267,7 +267,7 @@ public class Commands extends AbstractExecScript {
     public ScriptOutput run(RunContext runContext) throws Exception {
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             this.commands
         );
 

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
@@ -145,7 +145,7 @@ public class Script extends AbstractExecScript {
 
         List<String> commandsArgs  = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             String.join(" ", "python", relativeScriptPath.toString())
         );
 

--- a/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Commands.java
+++ b/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Commands.java
@@ -81,7 +81,7 @@ public class Commands extends AbstractExecScript {
     public ScriptOutput run(RunContext runContext) throws Exception {
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             this.commands
         );
 

--- a/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Script.java
+++ b/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Script.java
@@ -149,7 +149,7 @@ public class Script extends AbstractExecScript {
 
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             String.join(" ", "Rscript", relativeScriptPath.toString())
         );
 

--- a/plugin-script-ruby/src/main/java/io/kestra/plugin/scripts/ruby/Commands.java
+++ b/plugin-script-ruby/src/main/java/io/kestra/plugin/scripts/ruby/Commands.java
@@ -116,7 +116,7 @@ public class Commands extends AbstractExecScript {
     public ScriptOutput run(RunContext runContext) throws Exception {
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             this.commands
         );
 

--- a/plugin-script-ruby/src/main/java/io/kestra/plugin/scripts/ruby/Script.java
+++ b/plugin-script-ruby/src/main/java/io/kestra/plugin/scripts/ruby/Script.java
@@ -133,7 +133,7 @@ public class Script extends AbstractExecScript {
 
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             String.join(" ", "ruby", relativeScriptPath.toString())
         );
 

--- a/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Commands.java
+++ b/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Commands.java
@@ -125,7 +125,7 @@ public class Commands extends AbstractExecScript {
     public ScriptOutput run(RunContext runContext) throws Exception {
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             this.commands
         );
 

--- a/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Script.java
+++ b/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Script.java
@@ -88,7 +88,7 @@ public class Script extends AbstractExecScript {
     public ScriptOutput run(RunContext runContext) throws Exception {
         List<String> commandsArgs = ScriptService.scriptCommands(
             this.interpreter,
-            this.beforeCommands,
+            getBeforeCommandsWithOptions(),
             this.script
         );
 

--- a/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/CommandsTest.java
+++ b/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/CommandsTest.java
@@ -102,7 +102,7 @@ class CommandsTest {
             .type(Commands.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .beforeCommands(List.of("set -e"))
+            .failFast(true)
             .commands(List.of("unknown", "echo 1"))
             .build();
 
@@ -124,6 +124,7 @@ class CommandsTest {
             .type(Commands.class.getName())
             .docker(dockerOptions)
             .runner(runner)
+            .failFast(false)
             .commands(List.of("unknown", "echo 1"))
             .build();
 


### PR DESCRIPTION
This commit adds the new task property failFast for Script and Commands tasks to add interpreter options for handling errors.