### PR TITLE
fix(docs): update task runner syntax in the examples

### DIFF
--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
@@ -55,7 +55,8 @@ tasks:
     type: io.kestra.plugin.scripts.python.Commands
     namespaceFiles:
       enabled: true
-    runner: PROCESS
+    taskRunner:
+      type: io.kestra.core.models.tasks.runners.types.ProcessTaskRunner
     beforeCommands:
       - conda activate myCondaEnv
     commands:
@@ -111,7 +112,8 @@ namespace: dev
 tasks:
   - id: hello
     type: io.kestra.plugin.scripts.python.Commands
-    runner: PROCESS
+    taskRunner:
+      type: io.kestra.core.models.tasks.runners.types.ProcessTaskRunner
     commands:
       - python ml_on_gpu.py
     workerGroup:
@@ -186,7 +188,8 @@ tasks:
         warningOnStdErr: false
         commands:
           - python examples/scripts/etl_script.py
-        runner: DOCKER
+        taskRunner:
+          type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
         docker:
           image: annageller/kestra:latest
           config: |

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
@@ -188,10 +188,9 @@ tasks:
         warningOnStdErr: false
         commands:
           - python examples/scripts/etl_script.py
+        containerImage: annageller/kestra:latest
         taskRunner:
           type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
-        docker:
-          image: annageller/kestra:latest
           config: |
             {
               "auths": {

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
@@ -82,8 +82,7 @@ tasks:
       - id: gitPythonScripts
         type: io.kestra.plugin.scripts.python.Commands
         warningOnStdErr: false
-        docker:
-          image: ghcr.io/kestra-io/pydata:latest
+        containerImage: ghcr.io/kestra-io/pydata:latest
         beforeCommands:
           - pip install faker > /dev/null
         commands:
@@ -142,8 +141,7 @@ tasks:
         inputFiles:
           data.csv: "{{ trigger.objects | jq('.[].uri') | first }}"
         description: this script reads a file `data.csv` from S3 trigger
-        docker:
-          image: ghcr.io/kestra-io/pydata:latest
+        containerImage: ghcr.io/kestra-io/pydata:latest
         warningOnStdErr: false
         commands:
           - python examples/scripts/clean_messy_dataset.py

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
@@ -74,8 +74,7 @@ namespace: dev
 tasks:
   - id: cleanDataset
     type: io.kestra.plugin.scripts.python.Script
-    docker:
-      image: ghcr.io/kestra-io/pydata:latest
+    containerImage: ghcr.io/kestra-io/pydata:latest
     script: |
       import pandas as pd
       df = pd.read_csv("https://huggingface.co/datasets/kestra/datasets/raw/main/csv/messy_dataset.csv")

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
@@ -91,7 +91,8 @@ tasks:
 
   - id: readFileFromPython
     type: io.kestra.plugin.scripts.shell.Commands
-    runner: PROCESS
+    taskRunner:
+      type: io.kestra.core.models.tasks.runners.types.ProcessTaskRunner
     commands:
       - head -n 10 {{outputs.cleanDataset.outputFiles['clean_dataset.csv']}}
                 """

--- a/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Script.java
+++ b/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Script.java
@@ -92,8 +92,7 @@ import java.util.Map;
                   - id: r
                     type: io.kestra.plugin.scripts.r.Script
                     warningOnStdErr: false
-                    docker:
-                      image: ghcr.io/kestra-io/rdata:latest
+                    containerImage: ghcr.io/kestra-io/rdata:latest
                     script: "{{ read('main.R') }}
                     outputFiles:
                       - "*.csv"

--- a/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Commands.java
+++ b/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Commands.java
@@ -67,11 +67,11 @@ import jakarta.validation.constraints.NotEmpty;
         @Example(
             title = "Run a PHP Docker container and execute a command.",
             code = {
-                "runner: DOCKER",
-                "docker:",
-                "  image: php",
+                "taskRunner:",
+                "  type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner",
+                "containerImage: php",
                 "commands:",
-                "  - php -r 'print(phpversion() . \"\\n\");'",
+                "  - php -r 'print(phpversion());'",
             }
         ),
         @Example(

--- a/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Commands.java
+++ b/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Commands.java
@@ -36,8 +36,7 @@ import jakarta.validation.constraints.NotEmpty;
                 type: io.kestra.plugin.scripts.shell.Commands
                 commands:
                   - etl
-                docker:
-                  image: ghcr.io/kestra-io/rust:latest
+                containerImage: ghcr.io/kestra-io/rust:latest
                 outputFiles:
                   - "*.csv"
             """

--- a/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Script.java
+++ b/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Script.java
@@ -46,7 +46,8 @@ import jakarta.validation.constraints.NotNull;
                 tasks:
                   - id: hello
                     type: io.kestra.plugin.scripts.shell.Script
-                    runner: PROCESS
+                    taskRunner:
+                      type: io.kestra.core.models.tasks.runners.types.ProcessTaskRunner
                     script: |
                       echo "Hello world!" > {{ outputDir }}/hello.txt"""
         )        


### PR DESCRIPTION
### What changes are being made and why?
- Change task runner syntax to new format as the old format is being depreciated soon.

Example:

```yaml
tasks:
  - id: example_task
    type: io.kestra.plugin.scripts.shell.Commands
    runner: DOCKER
```

to:

```yaml
tasks:
  - id: example_task
    type: io.kestra.plugin.scripts.shell.Commands
    taskRunner:
      type: io.kestra.plugin.scripts.runner.docker.DockerTaskRunner
```
