### PR TITLE
fix: rollback commands to PluginProperty to permit workingDir rendering

### DIFF
--- a/plugin-script-groovy/src/test/java/io/kestra/plugin/scripts/groovy/EvalTest.java
+++ b/plugin-script-groovy/src/test/java/io/kestra/plugin/scripts/groovy/EvalTest.java
@@ -13,7 +13,7 @@ class EvalTest extends io.kestra.plugin.scripts.jvm.EvalTest {
             .id("unit-test")
             .type(Eval.class.getName())
             .outputs(Property.of(Arrays.asList("out", "map")))
-            .script(Property.of("import io.kestra.core.models.executions.metrics.Counter\n" +
+            .script("import io.kestra.core.models.executions.metrics.Counter\n" +
                 "\n" +
                 "logger.info('executionId: {}', runContext.render('{{ execution.id }}'))\n" +
                 "runContext.metric(Counter.of('total', 666, 'name', 'bla'))\n" +
@@ -24,7 +24,7 @@ class EvalTest extends io.kestra.plugin.scripts.jvm.EvalTest {
                 "output.write('555\\n666\\n'.getBytes())\n" +
                 "\n" +
                 "out = runContext.storage().putFile(tempFile)"
-            ))
+            )
             .build();
     }
 }

--- a/plugin-script-groovy/src/test/java/io/kestra/plugin/scripts/groovy/FileTransformTest.java
+++ b/plugin-script-groovy/src/test/java/io/kestra/plugin/scripts/groovy/FileTransformTest.java
@@ -27,14 +27,14 @@ class FileTransformTest extends io.kestra.plugin.scripts.jvm.FileTransformTest {
             .type(FileTransform.class.getName())
             .from(source)
             .concurrent(10)
-            .script(Property.of("logger.info('row: {}', row)\n" +
+            .script("logger.info('row: {}', row)\n" +
                 "sleep(1000)\n" +
                 "if (row.get('name') == 'richard') {\n" +
                 "  row = null\n" +
                 "} else {\n" +
                 "  row.put('email', row.get('name') + '@kestra.io')\n" +
                 "}\n"
-            ))
+            )
             .build();
     }
 
@@ -45,7 +45,7 @@ class FileTransformTest extends io.kestra.plugin.scripts.jvm.FileTransformTest {
             .type(FileTransform.class.getName())
             .from(source)
             .concurrent(10)
-            .script(Property.of("rows = [1, 2, row, [\"action\": \"insert\"]]\n"))
+            .script("rows = [1, 2, row, [\"action\": \"insert\"]]\n")
             .build();
     }
 }

--- a/plugin-script-jbang/src/main/java/io/kestra/plugin/scripts/jbang/Commands.java
+++ b/plugin-script-jbang/src/main/java/io/kestra/plugin/scripts/jbang/Commands.java
@@ -55,7 +55,7 @@ public class Commands extends AbstractExecScript {
         title = "JBangs commands to run."
     )
     @NotNull
-    private Property<List<String>> commands;
+    private List<String> commands;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -69,12 +69,11 @@ public class Commands extends AbstractExecScript {
 
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
-        var renderedCommands = runContext.render(this.commands).asList(String.class);
 
         List<String> commandsArgs = ScriptService.scriptCommands(
             runContext.render(this.interpreter).asList(String.class),
             getBeforeCommandsWithOptions(runContext),
-            renderedCommands,
+            commands,
             runContext.render(this.targetOS).as(TargetOS.class).orElse(null)
         );
 

--- a/plugin-script-jbang/src/main/java/io/kestra/plugin/scripts/jbang/Script.java
+++ b/plugin-script-jbang/src/main/java/io/kestra/plugin/scripts/jbang/Script.java
@@ -113,7 +113,7 @@ public class Script extends AbstractExecScript {
         title = "The inline script content. This property is intended for the script file's content as a (multiline) string, not a path to a file. To run a command from a file such as `jbang hello.java` or an executable JAR, use the `Commands` task instead."
     )
     @NotNull
-    private Property<String> script;
+    private String script;
 
     @Schema(
         title = "The JBang script extension.",
@@ -151,7 +151,7 @@ public class Script extends AbstractExecScript {
         Path relativeScriptPath = runContext.workingDir().path().relativize(runContext.workingDir().createTempFile(runContext.render(extension).as(String.class).orElseThrow()));
         inputFiles.put(
             relativeScriptPath.toString(),
-            commands.render(runContext, runContext.render(this.script).as(String.class).orElseThrow(), internalToLocalFiles)
+            commands.render(runContext, this.script, internalToLocalFiles)
         );
         commands = commands.withInputFiles(inputFiles);
 

--- a/plugin-script-jbang/src/test/java/io/kestra/plugin/scripts/jbang/CommandsTest.java
+++ b/plugin-script-jbang/src/test/java/io/kestra/plugin/scripts/jbang/CommandsTest.java
@@ -64,7 +64,7 @@ class CommandsTest {
         Commands bash = Commands.builder()
             .id("unit-test")
             .type(Commands.class.getName())
-            .commands(Property.of(List.of("jbang --quiet " + put.toString())))
+            .commands(List.of("jbang --quiet " + put.toString()))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-jbang/src/test/java/io/kestra/plugin/scripts/jbang/ScriptTest.java
+++ b/plugin-script-jbang/src/test/java/io/kestra/plugin/scripts/jbang/ScriptTest.java
@@ -40,7 +40,7 @@ class ScriptTest {
         bash = Script.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .script(Property.of("""
+            .script("""
                 class helloworld {
                     public static void main(String[] args) {
                         if(args.length==0) {
@@ -50,7 +50,7 @@ class ScriptTest {
                         }
                     }
                 }"""
-            ))
+            )
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-julia/src/main/java/io/kestra/plugin/scripts/julia/Commands.java
+++ b/plugin-script-julia/src/main/java/io/kestra/plugin/scripts/julia/Commands.java
@@ -63,7 +63,8 @@ public class Commands extends AbstractExecScript {
         title = "The commands to run."
     )
     @NotNull
-    protected Property<List<String>> commands;
+    @PluginProperty(dynamic = true)
+    protected List<String> commands;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -77,12 +78,11 @@ public class Commands extends AbstractExecScript {
 
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
-        var renderedCommands = runContext.render(this.commands).asList(String.class);
 
         List<String> commandsArgs = ScriptService.scriptCommands(
             runContext.render(this.interpreter).asList(String.class),
             getBeforeCommandsWithOptions(runContext),
-            renderedCommands,
+            commands,
             runContext.render(this.targetOS).as(TargetOS.class).orElse(null)
         );
 

--- a/plugin-script-julia/src/main/java/io/kestra/plugin/scripts/julia/Script.java
+++ b/plugin-script-julia/src/main/java/io/kestra/plugin/scripts/julia/Script.java
@@ -65,7 +65,8 @@ public class Script extends AbstractExecScript {
         title = "The inline script content. This property is intended for the script file's content as a (multiline) string, not a path to a file. To run a command such as `julia myscript.jl`, use the `Commands` task instead."
     )
     @NotNull
-    protected Property<String> script;
+    @PluginProperty(dynamic = true)
+    protected String script;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -86,7 +87,7 @@ public class Script extends AbstractExecScript {
         Path relativeScriptPath = runContext.workingDir().path().relativize(runContext.workingDir().createTempFile(".jl"));
         inputFiles.put(
             relativeScriptPath.toString(),
-            commands.render(runContext, runContext.render(this.script).as(String.class).orElse(null), internalToLocalFiles)
+            commands.render(runContext, this.script, internalToLocalFiles)
         );
         commands = commands.withInputFiles(inputFiles);
 

--- a/plugin-script-julia/src/test/java/io/kestra/plugin/scripts/julia/CommandsTest.java
+++ b/plugin-script-julia/src/test/java/io/kestra/plugin/scripts/julia/CommandsTest.java
@@ -55,7 +55,7 @@ class CommandsTest {
         Commands bash = Commands.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .commands(Property.of(List.of("julia " + put.toString())))
+            .commands(List.of("julia " + put.toString()))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-julia/src/test/java/io/kestra/plugin/scripts/julia/ScriptTest.java
+++ b/plugin-script-julia/src/test/java/io/kestra/plugin/scripts/julia/ScriptTest.java
@@ -38,7 +38,7 @@ class ScriptTest {
         Script bash = Script.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .script(Property.of("@info \"hello there!\""))
+            .script("@info \"hello there!\"")
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-jython/src/test/java/io/kestra/plugin/scripts/jython/EvalTest.java
+++ b/plugin-script-jython/src/test/java/io/kestra/plugin/scripts/jython/EvalTest.java
@@ -13,7 +13,7 @@ class EvalTest extends io.kestra.plugin.scripts.jvm.EvalTest {
             .id("unit-test")
             .type(Eval.class.getName())
             .outputs(Property.of(Arrays.asList("out", "map")))
-            .script(Property.of("from io.kestra.core.models.executions.metrics import Counter\n" +
+            .script("from io.kestra.core.models.executions.metrics import Counter\n" +
                 "import tempfile\n" +
                 "from java.io import File\n" +
                 "\n" +
@@ -25,7 +25,7 @@ class EvalTest extends io.kestra.plugin.scripts.jvm.EvalTest {
                 "tempFile.write('555\\n666\\n')\n" +
                 "\n" +
                 "out = runContext.storage().putFile(File(tempFile.name))"
-            ))
+            )
             .build();
     }
 }

--- a/plugin-script-jython/src/test/java/io/kestra/plugin/scripts/jython/FileTransformTest.java
+++ b/plugin-script-jython/src/test/java/io/kestra/plugin/scripts/jython/FileTransformTest.java
@@ -12,12 +12,12 @@ class FileTransformTest extends io.kestra.plugin.scripts.jvm.FileTransformTest {
             .id("unit-test")
             .type(Eval.class.getName())
             .from(source)
-            .script(Property.of("logger.info('row: {}', row)\n" +
+            .script("logger.info('row: {}', row)\n" +
                 "if row['name'] == 'richard': \n" +
                 "  row = None\n" +
                 "else: \n" +
                 "  row['email'] = row['name'] + '@kestra.io'\n"
-            ))
+            )
             .build();
     }
 
@@ -27,7 +27,7 @@ class FileTransformTest extends io.kestra.plugin.scripts.jvm.FileTransformTest {
             .id("unit-test")
             .type(Eval.class.getName())
             .from(source)
-            .script(Property.of("rows = [1, 2 , row, {\"action\": \"insert\"}]\n"))
+            .script("rows = [1, 2 , row, {\"action\": \"insert\"}]\n")
             .build();
     }
 }

--- a/plugin-script-nashorn/src/test/java/io/kestra/plugin/scripts/nashorn/EvalTest.java
+++ b/plugin-script-nashorn/src/test/java/io/kestra/plugin/scripts/nashorn/EvalTest.java
@@ -14,7 +14,7 @@ class EvalTest extends io.kestra.plugin.scripts.jvm.EvalTest {
             .id("unit-test")
             .type(Eval.class.getName())
             .outputs(Property.of(Arrays.asList("out", "map")))
-            .script(Property.of("var Counter = Java.type('io.kestra.core.models.executions.metrics.Counter');\n" +
+            .script("var Counter = Java.type('io.kestra.core.models.executions.metrics.Counter');\n" +
                 "var File = Java.type('java.io.File');\n" +
                 "var FileOutputStream = Java.type('java.io.FileOutputStream');\n" +
                 "\n" +
@@ -27,7 +27,7 @@ class EvalTest extends io.kestra.plugin.scripts.jvm.EvalTest {
                 "output.write('555\\n666\\n'.getBytes())\n" +
                 "\n" +
                 "out = runContext.storage().putFile(tempFile)"
-            ))
+            )
             .build();
     }
 }

--- a/plugin-script-nashorn/src/test/java/io/kestra/plugin/scripts/nashorn/FileTransformTest.java
+++ b/plugin-script-nashorn/src/test/java/io/kestra/plugin/scripts/nashorn/FileTransformTest.java
@@ -12,13 +12,13 @@ class FileTransformTest extends io.kestra.plugin.scripts.jvm.FileTransformTest {
             .id("unit-test")
             .type(Eval.class.getName())
             .from(source)
-            .script(Property.of("logger.info('row: {}', row)\n" +
+            .script("logger.info('row: {}', row)\n" +
                 "if (row['name'] == 'richard') {\n" +
                 "  row = null;\n" +
                 "} else {\n" +
                 "  row['email'] = row['name'] + '@kestra.io';\n" +
                 "}\n"
-            ))
+            )
             .build();
     }
 
@@ -28,7 +28,7 @@ class FileTransformTest extends io.kestra.plugin.scripts.jvm.FileTransformTest {
             .id("unit-test")
             .type(Eval.class.getName())
             .from(source)
-            .script(Property.of("rows = [1, 2, row, {\"action\": \"insert\"}]\n"))
+            .script("rows = [1, 2, row, {\"action\": \"insert\"}]\n")
             .build();
     }
 }

--- a/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/Commands.java
+++ b/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/Commands.java
@@ -60,7 +60,8 @@ public class Commands extends AbstractExecScript {
         title = "The commands to run."
     )
     @NotNull
-    protected Property<List<String>> commands;
+    @PluginProperty(dynamic = true)
+    protected List<String> commands;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -74,11 +75,10 @@ public class Commands extends AbstractExecScript {
 
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
-        var renderedCommands = runContext.render(this.commands).asList(String.class);
         List<String> commandsArgs = ScriptService.scriptCommands(
             runContext.render(this.interpreter).asList(String.class),
             getBeforeCommandsWithOptions(runContext),
-            renderedCommands,
+            commands,
             runContext.render(this.targetOS).as(TargetOS.class).orElse(null)
         );
 

--- a/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/Script.java
+++ b/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/Script.java
@@ -130,7 +130,8 @@ public class Script extends AbstractExecScript {
         title = "The inline script content. This property is intended for the script file's content as a (multiline) string, not a path to a file. To run a command from a file such as `bash myscript.sh` or `python myscript.py`, use the `Commands` task instead."
     )
     @NotNull
-    protected Property<String> script;
+    @PluginProperty(dynamic = true)
+    protected String script;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -151,7 +152,7 @@ public class Script extends AbstractExecScript {
         Path relativeScriptPath = runContext.workingDir().path().relativize(runContext.workingDir().createTempFile(".js"));
         inputFiles.put(
             relativeScriptPath.toString(),
-            commands.render(runContext, runContext.render(this.script).as(String.class).orElse(null), internalToLocalFiles)
+            commands.render(runContext, this.script, internalToLocalFiles)
         );
         commands = commands.withInputFiles(inputFiles);
 

--- a/plugin-script-node/src/test/java/io/kestra/plugin/scripts/node/CommandsTest.java
+++ b/plugin-script-node/src/test/java/io/kestra/plugin/scripts/node/CommandsTest.java
@@ -55,7 +55,7 @@ class CommandsTest {
         Commands bash = Commands.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .commands(Property.of(List.of("node " + put.toString())))
+            .commands(List.of("node " + put.toString()))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-node/src/test/java/io/kestra/plugin/scripts/node/ScriptTest.java
+++ b/plugin-script-node/src/test/java/io/kestra/plugin/scripts/node/ScriptTest.java
@@ -38,7 +38,7 @@ class ScriptTest {
         Script bash = Script.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .script(Property.of("console.log('hello there!')"))
+            .script("console.log('hello there!')")
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-powershell/src/main/java/io/kestra/plugin/scripts/powershell/Commands.java
+++ b/plugin-script-powershell/src/main/java/io/kestra/plugin/scripts/powershell/Commands.java
@@ -57,7 +57,8 @@ public class Commands extends AbstractExecScript {
         title = "The commands to run."
     )
     @NotNull
-    protected Property<List<String>> commands;
+    @PluginProperty(dynamic = true)
+    protected List<String> commands;
 
     @Builder.Default
     @Schema(
@@ -80,12 +81,11 @@ public class Commands extends AbstractExecScript {
 
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
-        var renderedCommands = runContext.render(this.commands).asList(String.class);
 
         List<String> commandsArgs = ScriptService.scriptCommands(
             runContext.render(this.interpreter).asList(String.class),
             getBeforeCommandsWithOptions(runContext),
-            renderedCommands,
+            commands,
             runContext.render(this.targetOS).as(TargetOS.class).orElse(null)
         );
 

--- a/plugin-script-powershell/src/main/java/io/kestra/plugin/scripts/powershell/Script.java
+++ b/plugin-script-powershell/src/main/java/io/kestra/plugin/scripts/powershell/Script.java
@@ -76,7 +76,8 @@ public class Script extends AbstractExecScript {
         title = "The inline script content. This property is intended for the script file's content as a (multiline) string, not a path to a file. To run a command from a file such as `bash myscript.sh` or `python myscript.py`, use the `Commands` task instead."
     )
     @NotNull
-    protected Property<String> script;
+    @PluginProperty(dynamic = true)
+    protected String script;
 
     @Builder.Default
     @Schema(
@@ -103,7 +104,7 @@ public class Script extends AbstractExecScript {
         Path relativeScriptPath = runContext.workingDir().path().relativize(runContext.workingDir().createTempFile(".ps1"));
         inputFiles.put(
             relativeScriptPath.toString(),
-            commands.render(runContext, runContext.render(this.script).as(String.class).orElse(null), internalToLocalFiles)
+            commands.render(runContext, this.script, internalToLocalFiles)
         );
         commands = commands.withInputFiles(inputFiles);
 

--- a/plugin-script-powershell/src/test/java/io/kestra/plugin/scripts/powershell/CommandsTest.java
+++ b/plugin-script-powershell/src/test/java/io/kestra/plugin/scripts/powershell/CommandsTest.java
@@ -59,7 +59,7 @@ class CommandsTest {
         Commands bash = Commands.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .commands(Property.of(List.of("pwsh " + put.toString())))
+            .commands(List.of("pwsh " + put.toString()))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
@@ -79,7 +79,7 @@ class CommandsTest {
         Commands bash = Commands.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .commands(Property.of(List.of("Get-ChildItem -Path \"NonexistentPath\"", "echo \"This is a message\"")))
+            .commands(List.of("Get-ChildItem -Path \"NonexistentPath\"", "echo \"This is a message\""))
             .failFast(Property.of(true))
             .build();
 
@@ -92,7 +92,7 @@ class CommandsTest {
         Commands bash = Commands.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .commands(Property.of(List.of("Get-ChildItem -Path \"NonexistentPath\"", "echo \"This is a message\"")))
+            .commands(List.of("Get-ChildItem -Path \"NonexistentPath\"", "echo \"This is a message\""))
             .failFast(Property.of(false))
             .build();
 

--- a/plugin-script-powershell/src/test/java/io/kestra/plugin/scripts/powershell/ScriptTest.java
+++ b/plugin-script-powershell/src/test/java/io/kestra/plugin/scripts/powershell/ScriptTest.java
@@ -38,7 +38,7 @@ class ScriptTest {
         Script bash = Script.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .script(Property.of("'Hello, World!' | Write-Output"))
+            .script("'Hello, World!' | Write-Output")
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.scripts.python;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.runners.ScriptService;
 import io.kestra.core.models.tasks.runners.TargetOS;
@@ -244,7 +245,8 @@ public class Commands extends AbstractExecScript {
         title = "The commands to run."
     )
     @NotNull
-    protected Property<List<String>> commands;
+    @PluginProperty(dynamic = true)
+    protected List<String> commands;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -258,12 +260,11 @@ public class Commands extends AbstractExecScript {
 
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
-        var renderedCommand = runContext.render(this.commands).asList(String.class);
 
         List<String> commandsArgs = ScriptService.scriptCommands(
             Property.asList(this.interpreter, runContext, String.class),
             getBeforeCommandsWithOptions(runContext),
-            renderedCommand,
+            commands,
             runContext.render(this.targetOS).as(TargetOS.class).orElse(null)
         );
 

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.scripts.python;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.runners.ScriptService;
 import io.kestra.core.models.tasks.runners.TargetOS;
@@ -173,7 +174,8 @@ public class Script extends AbstractExecScript {
         title = "The inline script content. This property is intended for the script file's content as a (multiline) string, not a path to a file. To run a command from a file such as `bash myscript.sh` or `python myscript.py`, use the `Commands` task instead."
     )
     @NotNull
-    protected Property<String> script;
+    @PluginProperty(dynamic = true)
+    protected String script;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -192,10 +194,9 @@ public class Script extends AbstractExecScript {
         Map<String, String> inputFiles = FilesService.inputFiles(runContext, commands.getTaskRunner().additionalVars(runContext, commands), this.getInputFiles());
         List<String> internalToLocalFiles = new ArrayList<>();
         Path relativeScriptPath = runContext.workingDir().path().relativize(runContext.workingDir().createTempFile(".py"));
-        String renderedScript = runContext.render(this.script).as(String.class).orElse(null);
         inputFiles.put(
             relativeScriptPath.toString(),
-            commands.render(runContext, renderedScript, internalToLocalFiles)
+            commands.render(runContext, this.script, internalToLocalFiles)
         );
         commands = commands.withInputFiles(inputFiles);
 

--- a/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/CommandsTest.java
+++ b/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/CommandsTest.java
@@ -55,7 +55,7 @@ class CommandsTest {
         Commands task = Commands.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .commands(Property.of(List.of("python " + put.toString())))
+            .commands(List.of("python " + put.toString()))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());

--- a/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/ScriptTest.java
+++ b/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/ScriptTest.java
@@ -53,7 +53,7 @@ class ScriptTest {
             .type(Script.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .script(Property.of("print('::{\"outputs\": {\"extract\":\"hello world\"}}::')"))
+            .script("print('::{\"outputs\": {\"extract\":\"hello world\"}}::')")
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, python, ImmutableMap.of());
@@ -72,7 +72,7 @@ class ScriptTest {
             .type(Script.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .script(Property.of("import sys; sys.exit(1)"))
+            .script("import sys; sys.exit(1)")
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, python, ImmutableMap.of());
@@ -92,9 +92,9 @@ class ScriptTest {
             .type(Script.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .script(Property.of("import requests;" +
+            .script("import requests;" +
                 "print('::{\"outputs\": {\"extract\":\"' + str(requests.get('https://google.com').status_code) + '\"}}::')"
-            ))
+            )
             .beforeCommands(Property.of(List.of(
                 "python3 -m venv venv",
                 ". venv/bin/activate",
@@ -127,11 +127,11 @@ class ScriptTest {
             .type(Script.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .script(Property.of("import os\n" +
+            .script("import os\n" +
                 "\n" +
                 "file_size = os.path.getsize(\"" + put.toString() + "\")\n" +
                 "print('::{\"outputs\": {\"extract\":' + str(file_size) + '}}::')"
-            ))
+            )
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, python, ImmutableMap.of());
@@ -149,10 +149,10 @@ class ScriptTest {
             .type(Script.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .script(Property.of("from kestra import Kestra\n" +
+            .script("from kestra import Kestra\n" +
                 "print(\"1234\\n\\n\")\n" +
                 "Kestra.outputs({'secrets': \"test string\"})"
-            ))
+            )
             .beforeCommands(Property.of(List.of(
                 "python -m venv venv",
                 ". venv/bin/activate",
@@ -196,14 +196,14 @@ class ScriptTest {
             .type(Script.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .script(Property.of("from kestra import Kestra\n" +
+            .script("from kestra import Kestra\n" +
                 "import time\n" +
                 "Kestra.outputs({'test': 'value', 'int': 2, 'bool': True, 'float': 3.65})\n" +
                 "Kestra.counter('count', 1, {'tag1': 'i', 'tag2': 'win'})\n" +
                 "Kestra.counter('count2', 2)\n" +
                 "Kestra.timer('timer1', lambda: time.sleep(1), {'tag1': 'i', 'tag2': 'lost'})\n" +
                 "Kestra.timer('timer2', 2.12, {'tag1': 'i', 'tag2': 'destroy'})\n"
-            ))
+            )
             .beforeCommands(Property.of(List.of(
                 "python -m venv venv",
                 ". venv/bin/activate",

--- a/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Commands.java
+++ b/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Commands.java
@@ -61,7 +61,8 @@ public class Commands extends AbstractExecScript {
         title = "The commands to run"
     )
     @NotNull
-    protected Property<List<String>> commands;
+    @PluginProperty(dynamic = true)
+    protected List<String> commands;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -75,12 +76,11 @@ public class Commands extends AbstractExecScript {
 
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
-        var renderedCommands = runContext.render(this.commands).asList(String.class);
 
         List<String> commandsArgs = ScriptService.scriptCommands(
             runContext.render(this.interpreter).asList(String.class),
             getBeforeCommandsWithOptions(runContext),
-            renderedCommands,
+            commands,
             runContext.render(this.targetOS).as(TargetOS.class).orElse(null)
         );
 

--- a/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Script.java
+++ b/plugin-script-r/src/main/java/io/kestra/plugin/scripts/r/Script.java
@@ -115,7 +115,8 @@ public class Script extends AbstractExecScript {
         title = "The inline script content. This property is intended for the script file's content as a (multiline) string, not a path to a file. To run a command from a file such as `Rscript main.R` or `python main.py`, use the corresponding `Commands` task for a given language instead."
     )
     @NotNull
-    protected Property<String> script;
+    @PluginProperty(dynamic = true)
+    protected String script;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -136,7 +137,7 @@ public class Script extends AbstractExecScript {
         Path relativeScriptPath = runContext.workingDir().path().relativize(runContext.workingDir().createTempFile(".R"));
         inputFiles.put(
             relativeScriptPath.toString(),
-            commands.render(runContext, runContext.render(this.script).as(String.class).orElse(null), internalToLocalFiles)
+            commands.render(runContext, this.script, internalToLocalFiles)
         );
         commands = commands.withInputFiles(inputFiles);
 

--- a/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/CommandsTest.java
+++ b/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/CommandsTest.java
@@ -56,7 +56,7 @@ class CommandsTest {
         Commands bash = Commands.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .commands(Property.of(List.of("Rscript " + put.toString())))
+            .commands(List.of("Rscript " + put.toString()))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/ScriptTest.java
+++ b/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/ScriptTest.java
@@ -42,12 +42,12 @@ class ScriptTest {
             .beforeCommands(Property.of(List.of(
                 "Rscript -e 'install.packages(\"lubridate\")'"
             )))
-            .script(Property.of("""
+            .script("""
                 library(lubridate)
                 ymd("20100604");
                 mdy("06-04-2011");
                 dmy("04/06/2012")"""
-            ))
+            )
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-ruby/src/main/java/io/kestra/plugin/scripts/ruby/Commands.java
+++ b/plugin-script-ruby/src/main/java/io/kestra/plugin/scripts/ruby/Commands.java
@@ -98,7 +98,8 @@ public class Commands extends AbstractExecScript {
         title = "The commands to run"
     )
     @NotNull
-    protected Property<List<String>> commands;
+    @PluginProperty(dynamic = true)
+    protected List<String> commands;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -112,12 +113,11 @@ public class Commands extends AbstractExecScript {
 
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
-        var renderedCommands = runContext.render(this.commands).asList(String.class);
 
         List<String> commandsArgs = ScriptService.scriptCommands(
             runContext.render(this.interpreter).asList(String.class),
             getBeforeCommandsWithOptions(runContext),
-            renderedCommands,
+            commands,
             runContext.render(this.targetOS).as(TargetOS.class).orElse(null)
         );
 

--- a/plugin-script-ruby/src/main/java/io/kestra/plugin/scripts/ruby/Script.java
+++ b/plugin-script-ruby/src/main/java/io/kestra/plugin/scripts/ruby/Script.java
@@ -100,7 +100,8 @@ public class Script extends AbstractExecScript {
         title = "The inline script content. This property is intended for the script file's content as a (multiline) string, not a path to a file. To run a command from a file such as `bash myscript.sh` or `python myscript.py`, use the `Commands` task instead."
     )
     @NotNull
-    protected Property<String> script;
+    @PluginProperty(dynamic = true)
+    protected String script;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -121,7 +122,7 @@ public class Script extends AbstractExecScript {
         Path relativeScriptPath = runContext.workingDir().path().relativize(runContext.workingDir().createTempFile(".rb"));
         inputFiles.put(
             relativeScriptPath.toString(),
-            commands.render(runContext, runContext.render(this.script).as(String.class).orElse(null), internalToLocalFiles)
+            commands.render(runContext, this.script, internalToLocalFiles)
         );
         commands = commands.withInputFiles(inputFiles);
 

--- a/plugin-script-ruby/src/test/java/io/kestra/plugin/scripts/ruby/CommandsTest.java
+++ b/plugin-script-ruby/src/test/java/io/kestra/plugin/scripts/ruby/CommandsTest.java
@@ -56,7 +56,7 @@ class CommandsTest {
         Commands bash = Commands.builder()
             .id("unit-test")
             .type(Script.class.getName())
-            .commands(Property.of(List.of("ruby " + put.toString())))
+            .commands(List.of("ruby " + put.toString()))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-ruby/src/test/java/io/kestra/plugin/scripts/ruby/ScriptTest.java
+++ b/plugin-script-ruby/src/test/java/io/kestra/plugin/scripts/ruby/ScriptTest.java
@@ -43,12 +43,12 @@ class ScriptTest {
             .beforeCommands(Property.of(List.of(
                 "gem install date"
             )))
-            .script(Property.of("""
+            .script("""
                 require 'date'
                 puts Date.new(2012,12,25).strftime('%F')
                 STDERR.puts Date.jd(2451944).strftime('%F')
                 """
-            ))
+            )
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Commands.java
+++ b/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Commands.java
@@ -193,7 +193,8 @@ public class Commands extends AbstractExecScript {
         title = "Shell commands to run."
     )
     @NotNull
-    protected Property<List<String>> commands;
+    @PluginProperty(dynamic = true)
+    protected List<String> commands;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -207,11 +208,10 @@ public class Commands extends AbstractExecScript {
 
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
-        var renderedCommands = runContext.render(this.commands).asList(String.class);
         List<String> commandsArgs = ScriptService.scriptCommands(
             runContext.render(this.interpreter).asList(String.class),
             getBeforeCommandsWithOptions(runContext),
-            renderedCommands,
+            commands,
             runContext.render(this.targetOS).as(TargetOS.class).orElse(null)
         );
 

--- a/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Script.java
+++ b/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/Script.java
@@ -81,7 +81,8 @@ public class Script extends AbstractExecScript {
         title = "The inline script content. This property is intended for the script file's content as a (multiline) string, not a path to a file. To run a command from a file such as `bash myscript.sh` or `python myscript.py`, use the `Commands` task instead."
     )
     @NotNull
-    protected Property<String> script;
+    @PluginProperty(dynamic = true)
+    protected String script;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -98,7 +99,7 @@ public class Script extends AbstractExecScript {
         List<String> commandsArgs = ScriptService.scriptCommands(
             runContext.render(this.interpreter).asList(String.class),
             getBeforeCommandsWithOptions(runContext),
-            runContext.render(this.script).as(String.class).orElseThrow(),
+            this.script,
             runContext.render(this.targetOS).as(TargetOS.class).orElse(null)
         );
 

--- a/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/CommandsTest.java
+++ b/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/CommandsTest.java
@@ -65,7 +65,7 @@ class CommandsTest {
             .type(Commands.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .commands(Property.of(List.of("echo 0", "echo 1", ">&2 echo 2", ">&2 echo 3")))
+            .commands(List.of("echo 0", "echo 1", ">&2 echo 2", ">&2 echo 3"))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
@@ -84,7 +84,7 @@ class CommandsTest {
             .type(Commands.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .commands(Property.of(List.of("echo 1 1>&2", "exit 66", "echo 2")))
+            .commands(List.of("echo 1 1>&2", "exit 66", "echo 2"))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
@@ -106,7 +106,7 @@ class CommandsTest {
             .docker(dockerOptions)
             .runner(runner)
             .failFast(Property.of(true))
-            .commands(Property.of(List.of("unknown", "echo 1")))
+            .commands(List.of("unknown", "echo 1"))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
@@ -128,7 +128,7 @@ class CommandsTest {
             .docker(dockerOptions)
             .runner(runner)
             .failFast(Property.of(false))
-            .commands(Property.of(List.of("unknown", "echo 1")))
+            .commands(List.of("unknown", "echo 1"))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
@@ -154,13 +154,13 @@ class CommandsTest {
             .type(Commands.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .commands(Property.of(List.of(
+            .commands(List.of(
                 "mkdir -p {{ outputDir}}/sub/dir/",
                 "echo '::{\"outputs\": {\"extract\":\"'$(cat " + put.toString() + ")'\"}}::'",
                 "echo 1 >> {{ outputDir}}/file.xml",
                 "echo 2 >> {{ outputDir}}/sub/dir/file.csv",
                 "echo 3 >> {{ outputDir}}/file.xml"
-            )))
+            ))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
@@ -197,9 +197,9 @@ class CommandsTest {
             .type(Commands.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .commands(Property.of(List.of(
+            .commands(List.of(
                 "echo '::{\"outputs\": {\"extract\":null}}::'"
-            )))
+            ))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
@@ -227,7 +227,7 @@ class CommandsTest {
                 .build()
             )
             .runner(RunnerType.DOCKER)
-            .commands(Property.of(List.of("pwd")))
+            .commands(List.of("pwd"))
             .build();
 
 
@@ -255,7 +255,7 @@ class CommandsTest {
                 .build()
             )
             .runner(RunnerType.DOCKER)
-            .commands(Property.of(List.of("pwd")))
+            .commands(List.of("pwd"))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
@@ -272,7 +272,7 @@ class CommandsTest {
             .type(Commands.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .commands(Property.of(List.of("echo {{ workingDir }}")))
+            .commands(List.of("echo {{ workingDir }}"))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/ScriptTest.java
+++ b/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/ScriptTest.java
@@ -62,12 +62,12 @@ class ScriptTest {
             .type(Script.class.getName())
             .docker(dockerOptions)
             .runner(runner)
-            .script(Property.of("""
+            .script("""
                 echo 0
                 echo 1
                 >&2 echo 2
                 >&2 echo 3
-            """))
+            """)
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
@@ -87,12 +87,12 @@ class ScriptTest {
             .docker(dockerOptions)
             .interpreter(Property.of(List.of("/bin/bash", "-c")))
             .runner(runner)
-            .script(Property.of("""
+            .script("""
                 for i in {1..2000}
                 do
                    echo "$i"
                 done
-            """))
+            """)
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
@@ -119,9 +119,9 @@ class ScriptTest {
                 )
                 .build()
             )
-            .script(Property.of("""
+            .script("""
                     echo '::{"outputs":{"config":'$(cat config.json)'}}::'
-                """))
+                """)
             .build();
 
 
@@ -150,10 +150,10 @@ class ScriptTest {
             ))
             .outputFiles(Property.of(
                 List.of("out/**")))
-            .script(Property.of("""
+            .script("""
                 mkdir out
                 cat test/application.yml > out/bla.yml
-            """))
+            """)
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());

--- a/plugin-script/src/main/java/io/kestra/plugin/scripts/jvm/AbstractJvmScript.java
+++ b/plugin-script/src/main/java/io/kestra/plugin/scripts/jvm/AbstractJvmScript.java
@@ -18,9 +18,9 @@ public abstract class AbstractJvmScript extends Task {
     @Schema(
         title = "A full script."
     )
-    protected Property<String> script;
+    protected String script;
 
     protected String generateScript(RunContext runContext) throws IllegalVariableEvaluationException {
-        return runContext.render(this.script).as(String.class).orElse(null);
+        return runContext.render(this.script);
     }
 }


### PR DESCRIPTION
fix: rollback commands to PluginProperty to permit workingDir rendering

WorkingDir is rendered inside Kestra. 
It is causing issue when present in `commands` or `script` because with Property we render them before going into kestra and they don't have access to the workingDir var.