### PR TITLE
Add uv fallback and classic pip/venv support for Python plugins

### DIFF
--- a/plugin-script-python/src/main/java/io/kestra/core/tasks/scripts/Python.java
+++ b/plugin-script-python/src/main/java/io/kestra/core/tasks/scripts/Python.java
@@ -171,14 +171,13 @@ public class Python extends AbstractBash implements RunnableTask<ScriptOutput> {
                 renderer.add("./.venv/bin/uv pip install " + runContext.render(String.join(" ", requirements), additionalVars) + " > /dev/null");
             }
         } else {
-        renderer.add(this.pythonPath + " -m venv --system-site-packages " + workingDirectory + " > /dev/null");
+            renderer.add(this.pythonPath + " -m venv --system-site-packages " + workingDirectory + " > /dev/null");
             if (requirements != null && !requirements.isEmpty()) {
                 renderer.addAll(Arrays.asList(
                 "./bin/pip install pip --upgrade > /dev/null",
                 "./bin/pip install " + runContext.render(String.join(" ", requirements), additionalVars) + " > /dev/null"));
             }
         }
-
 
         return String.join("\n", renderer);
     }

--- a/plugin-script-python/src/main/java/io/kestra/core/tasks/scripts/Python.java
+++ b/plugin-script-python/src/main/java/io/kestra/core/tasks/scripts/Python.java
@@ -244,7 +244,6 @@ public class Python extends AbstractBash implements RunnableTask<ScriptOutput> {
                     renderedCommand = renderedCommand.replace("./bin/python", "./.venv/bin/python");
                 }
 
-                // renderer.add(runContext.render(command, additionalVars) + argsString);
                 renderer.add(renderedCommand);
             }
 

--- a/plugin-script-python/src/main/java/io/kestra/core/tasks/scripts/Python.java
+++ b/plugin-script-python/src/main/java/io/kestra/core/tasks/scripts/Python.java
@@ -5,8 +5,10 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.scripts.python.internals.PackageManagerType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -55,7 +57,7 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
             code = """
                 id: python_flow
                 namespace: company.team
-                
+
                 tasks:
                   - id: python
                     type: io.kestra.core.tasks.scripts.Python
@@ -86,7 +88,7 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
             code = """
                 id: python_flow
                 namespace: company.team
-                
+
                 tasks:
                   - id: python
                     type: io.kestra.core.tasks.scripts.Python
@@ -146,19 +148,37 @@ public class Python extends AbstractBash implements RunnableTask<ScriptOutput> {
     @Builder.Default
     protected Boolean virtualEnv = true;
 
+    @Schema(
+        title = "Package manager for Python dependencies",
+        description = "Package manager to use for installing Python dependencies. " +
+            "Options: 'UV' (default), 'PIP'. ",
+        allowableValues = {"PIP", "UV"}
+    )
+    @Builder.Default
+    protected Property<PackageManagerType> packageManager = Property.ofValue(PackageManagerType.PIP);
+
     protected String virtualEnvCommand(RunContext runContext, List<String> requirements) throws IllegalVariableEvaluationException {
         List<String> renderer = new ArrayList<>();
+        var rPackageManager = PackageManagerType.UV.equals(runContext.render(packageManager).as(PackageManagerType.class).orElse(PackageManagerType.UV));
 
         if (runContext.render(this.exitOnFailed).as(Boolean.class).orElseThrow()) {
             renderer.add("set -o errexit");
         }
-        renderer.add(this.pythonPath + " -m venv --system-site-packages " + workingDirectory + " > /dev/null");
 
-        if (requirements != null) {
-            renderer.addAll(Arrays.asList(
+        if (rPackageManager) {
+            renderer.add("uv venv --system-site-packages .venv > /dev/null");
+            if (requirements != null && !requirements.isEmpty()) {
+                renderer.add("./.venv/bin/uv pip install " + runContext.render(String.join(" ", requirements), additionalVars) + " > /dev/null");
+            }
+        } else {
+        renderer.add(this.pythonPath + " -m venv --system-site-packages " + workingDirectory + " > /dev/null");
+            if (requirements != null && !requirements.isEmpty()) {
+                renderer.addAll(Arrays.asList(
                 "./bin/pip install pip --upgrade > /dev/null",
                 "./bin/pip install " + runContext.render(String.join(" ", requirements), additionalVars) + " > /dev/null"));
+            }
         }
+
 
         return String.join("\n", renderer);
     }
@@ -202,6 +222,7 @@ public class Python extends AbstractBash implements RunnableTask<ScriptOutput> {
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
         Map<String, String> finalInputFiles = this.finalInputFiles(runContext);
+        var rPackageManager = PackageManagerType.UV.equals(runContext.render(packageManager).as(PackageManagerType.class).orElse(PackageManagerType.UV));
 
         if (!finalInputFiles.containsKey("main.py") && this.commands.size() == 1 && this.commands.get(0).equals("./bin/python main.py")) {
             throw new Exception("Invalid input files structure, expecting inputFiles property to contain at least a main.py key with python code value.");
@@ -218,7 +239,13 @@ public class Python extends AbstractBash implements RunnableTask<ScriptOutput> {
             for (String command : commands) {
                 String argsString = args == null ? "" : " " + runContext.render(String.join(" ", args), additionalVars);
 
-                renderer.add(runContext.render(command, additionalVars) + argsString);
+                String renderedCommand = runContext.render(command, additionalVars) + argsString;
+                if (rPackageManager && renderedCommand.startsWith("./bin/python")) {
+                    renderedCommand = renderedCommand.replace("./bin/python", "./.venv/bin/python");
+                }
+
+                // renderer.add(runContext.render(command, additionalVars) + argsString);
+                renderer.add(renderedCommand);
             }
 
             return String.join("\n", renderer);

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/AbstractPythonExecScript.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/AbstractPythonExecScript.java
@@ -32,9 +32,11 @@ public abstract class AbstractPythonExecScript extends AbstractExecScript implem
     @Schema(
         title = "Package manager for Python dependencies",
         description = "Package manager to use for installing Python dependencies. " +
-            "Options: 'UV' (default), 'PIP'. ",
+            "Options: 'uv' (default), 'pip'. " +
+            "UV automatically falls back to PIP if not available.",
         allowableValues = {"PIP", "UV"}
     )
+    @PluginProperty
     @Builder.Default
     protected Property<PackageManagerType> packageManager = Property.ofValue(PackageManagerType.UV);
 }

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/AbstractPythonExecScript.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/AbstractPythonExecScript.java
@@ -1,8 +1,11 @@
 package io.kestra.plugin.scripts.python;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.plugin.scripts.exec.AbstractExecScript;
+import io.kestra.plugin.scripts.python.internals.PackageManagerType;
 import io.kestra.plugin.scripts.python.internals.PythonBasedPlugin;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -26,4 +29,12 @@ public abstract class AbstractPythonExecScript extends AbstractExecScript implem
 
     protected Property<Boolean> dependencyCacheEnabled = Property.of(true);
 
+    @Schema(
+        title = "Package manager for Python dependencies",
+        description = "Package manager to use for installing Python dependencies. " +
+            "Options: 'UV' (default), 'PIP'. ",
+        allowableValues = {"PIP", "UV"}
+    )
+    @Builder.Default
+    protected Property<PackageManagerType> packageManager = Property.ofValue(PackageManagerType.UV);
 }

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
@@ -3,7 +3,6 @@ package io.kestra.plugin.scripts.python;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.TargetOS;
@@ -15,7 +14,6 @@ import io.kestra.plugin.scripts.python.internals.PythonEnvironmentManager;
 import io.kestra.plugin.scripts.python.internals.PythonEnvironmentManager.ResolvedPythonEnvironment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -256,7 +254,7 @@ import java.util.Map;
                                 }
                             }
                           }
-                """
+              """
     ),
     @Example(
         full = true,
@@ -267,6 +265,7 @@ import java.util.Map;
             tasks:
               - id: python
                 type: io.kestra.plugin.scripts.python.Commands
+                packageManager: UV
                 inputFiles:
                   main.py: |
                     import requests

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Commands.java
@@ -3,16 +3,19 @@ package io.kestra.plugin.scripts.python;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.TargetOS;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.kestra.plugin.scripts.python.internals.PackageManagerType;
 import io.kestra.plugin.scripts.python.internals.PythonEnvironmentManager;
 import io.kestra.plugin.scripts.python.internals.PythonEnvironmentManager.ResolvedPythonEnvironment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -303,7 +306,8 @@ public class Commands extends AbstractPythonExecScript implements RunnableTask<S
     public ScriptOutput run(RunContext runContext) throws Exception {
         TargetOS os = runContext.render(this.targetOS).as(TargetOS.class).orElse(null);
 
-        PythonEnvironmentManager pythonEnvironmentManager = new PythonEnvironmentManager(runContext, this);
+        PackageManagerType resolvedPackageManager = runContext.render(this.packageManager).as(PackageManagerType.class).orElse(PackageManagerType.PIP);
+        PythonEnvironmentManager pythonEnvironmentManager = new PythonEnvironmentManager(runContext, this, resolvedPackageManager);
         ResolvedPythonEnvironment pythonEnvironment = pythonEnvironmentManager.setup(containerImage, taskRunner, runner);
 
         Map<String, String> env = new HashMap<>();

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
@@ -279,6 +279,7 @@ import java.util.Map;
                 tasks:
                   - id: generate_output
                     type: io.kestra.plugin.scripts.python.Script
+                    packageManager: PIP
                     dependencies:
                       - kestra
                     script: |

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
@@ -230,7 +230,7 @@ import java.util.Map;
                               print("{{ inputs.pokemon}} is too young!")
                       else:
                           print(f"Failed to retrieve the webpage. Status code: {response.status_code}")
-                  """
+                """
         ),
         @Example(
             full = true,
@@ -265,7 +265,7 @@ import java.util.Map;
                       num_rows = len(df)
 
                       print(f"Number of rows: {num_rows}")
-                  """
+                """
         ),
         @Example(
             full = true,
@@ -292,7 +292,7 @@ import java.util.Map;
                     message:
                       - "Total Marks: {{ outputs.generate_output.vars.total_marks }}"
                       - "Average Marks: {{ outputs.generate_output.vars.average_marks }}"
-                  """
+                """
         )
     }
 )

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PackageManagerType.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PackageManagerType.java
@@ -1,0 +1,163 @@
+package io.kestra.plugin.scripts.python.internals;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+public enum PackageManagerType {
+    UV("uv") {
+        @Override
+        public String getPythonPath(PythonDependenciesResolver resolver, String version) {
+            Optional<String> pythonPath = resolver.findPython(version);
+            if (pythonPath.isEmpty()) {
+                resolver.installPython(version);
+                pythonPath = resolver.findPython(version);
+            }
+            return pythonPath.orElseThrow(() ->
+                new KestraRuntimeException("Could not find or install Python '" + version + "' path"));
+        }
+
+        @Override
+        public ResolvedPythonPackages installPackages(PythonDependenciesResolver resolver,
+                                                      String pythonPath, String version, String hash,
+                                                      List<String> requirements, Path pythonLibDir) throws IOException {
+            Path in = resolver.createRequirementInFileAndGetPath(version, hash, requirements);
+
+            resolver.logger.debug("Compiling dependencies with uv");
+            Path req = resolver.workingDir.createFile(resolver.getRequirementTxtFilename(hash));
+
+            try {
+                resolver.execCommandAndGetStdOut(
+                    List.of(resolver.getUvCmd(), "pip", "compile",
+                        "--quiet",
+                        "--no-color",
+                        "--no-config",
+                        "--no-header",
+                        "--strip-extras",
+                        "--output-file", req.toString(),
+                        "--python", pythonPath,
+                        "--cache-dir", resolver.getUvCacheDir(),
+                        in.toString()
+                    )
+                );
+            } catch (IOException | InterruptedException e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                throw new KestraRuntimeException("Failed to wait for 'uv pip compile' command. Error " + e.getMessage());
+            }
+
+            resolver.logger.debug("Installing packages with uv");
+            try {
+                resolver.execCommandAndGetStdOut(
+                    List.of(resolver.getUvCmd(), "pip", "install",
+                        "--quiet",
+                        "--no-color",
+                        "--no-config",
+                        "--link-mode", "copy",
+                        "--reinstall",
+                        "--index-strategy", "unsafe-best-match",
+                        "--target=" + pythonLibDir,
+                        "--requirement=" + req,
+                        "--python", pythonPath,
+                        "--cache-dir", resolver.getUvCacheDir()
+                    )
+                );
+            } catch (IOException | InterruptedException e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                throw new KestraRuntimeException("Failed to wait for uv pip install command. Error " + e.getMessage());
+            }
+            return new ResolvedPythonPackages(pythonLibDir, req, hash, version);
+        }
+
+        @Override
+        public boolean isAvailable(PythonDependenciesResolver resolver) {
+            try {
+                String version = resolver.getUvVersion(resolver.getUvCmd());
+                return version != null;
+            } catch (Exception e) {
+                resolver.logger.debug("UV not available: {}", e.getMessage());
+                return false;
+            }
+        }
+    },
+
+    PIP("pip") {
+        @Override
+        public String getPythonPath(PythonDependenciesResolver resolver, String version) {
+            String[] candidates = version == null
+                ? new String[]{"python3", "python"}
+                : new String[]{"python" + version, "python" + version.charAt(0) + "." + version.charAt(2), "python3", "python"};
+            for (String candidate : candidates) {
+                try {
+                    Process process = new ProcessBuilder(candidate, "--version").start();
+                    int exitCode = process.waitFor();
+                    if (exitCode == 0) {
+                        return candidate;
+                    }
+                } catch (Exception ignored) {}
+            }
+            throw new KestraRuntimeException("Could not find a suitable Python interpreter for version: " + version);
+        }
+
+        @Override
+        public ResolvedPythonPackages installPackages(PythonDependenciesResolver resolver,
+                                                      String pythonPath, String version, String hash,
+                                                      List<String> requirements, Path pythonLibDir) throws IOException {
+            Path req = resolver.workingDir.createFile(resolver.getRequirementTxtFilename(hash));
+            Files.write(req, requirements, StandardCharsets.UTF_8);
+
+            resolver.logger.debug("Installing packages with pip");
+            try {
+                resolver.execCommandAndGetStdOut(
+                    List.of(pythonPath, "-m", "pip", "install",
+                        "--quiet",
+                        "--no-cache-dir",
+                        "--target=" + pythonLibDir,
+                        "--requirement=" + req
+                    )
+                );
+            } catch (IOException | InterruptedException e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                throw new KestraRuntimeException("Failed to wait for pip install command. Error " + e.getMessage());
+            }
+            return new ResolvedPythonPackages(pythonLibDir, req, hash, version);
+        }
+
+        @Override
+        public boolean isAvailable(PythonDependenciesResolver resolver) {
+            return true;
+        }
+    };
+
+    private final String displayName;
+
+    PackageManagerType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public abstract String getPythonPath(PythonDependenciesResolver resolver, String version);
+
+    public abstract ResolvedPythonPackages installPackages(PythonDependenciesResolver resolver,
+                                                           String pythonPath, String version, String hash,
+                                                           List<String> requirements, Path pythonLibDir) throws IOException;
+
+    public abstract boolean isAvailable(PythonDependenciesResolver resolver);
+
+    public static PackageManagerType from(Boolean useUv) {
+        return Boolean.TRUE.equals(useUv) ? UV : PIP;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonDependenciesResolver.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonDependenciesResolver.java
@@ -54,9 +54,9 @@ public class PythonDependenciesResolver {
     /**
      * Gets the path for the Python interpreter.
      *
-     * Uses different logic based on the `useUv` flag.
-     * - If useUv is true: attempts to find and install the specified Python version.
-     * - If useUv is false: tries to find a system-wide Python interpreter.
+     * Uses different logic based on the `packageManager` property.
+     * - If packageManager is 'UV': attempts to find and install the specified Python version.
+     * - If packageManager is 'PIP': tries to find a system-wide Python interpreter.
      *
      * @param version The desired Python version (may be null).
      * @return The path to the Python interpreter.

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonDependenciesResolver.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonDependenciesResolver.java
@@ -30,36 +30,42 @@ public class PythonDependenciesResolver {
     private static final String PATH_ENV = System.getenv("PATH");
     private static final String WORKING_DIR_ADDITIONAL_PYTHON_LIB = ".kestra_additional_python_lib";
 
-    private final Logger logger;
-    private final WorkingDir workingDir;
+    protected final Logger logger;
+    protected final WorkingDir workingDir;
     private final Path localCacheDir;
     private String uvCmd;
+    private final PackageManagerType packageManagerType;
 
     /**
      * Creates a new {@link PythonDependenciesResolver} instance.
      *
+     * @param logger The logger instance.
      * @param workingDir The {@link WorkingDir}.
+     * @param localCacheDir The local cache directory.
+     * @param packageManagerType The package manager type to use.
      */
-    public PythonDependenciesResolver(final Logger logger, final WorkingDir workingDir, final Path localCacheDir) {
+    public PythonDependenciesResolver(final Logger logger, final WorkingDir workingDir, final Path localCacheDir, final PackageManagerType packageManagerType) {
         this.workingDir = Objects.requireNonNull(workingDir, "workingDir cannot be null");
         this.logger = Objects.requireNonNull(logger, "logger cannot be null");
         this.localCacheDir = Objects.requireNonNull(localCacheDir, "localCacheDir cannot be null");
+        this.packageManagerType = Objects.requireNonNull(packageManagerType, "packageManagerType cannot be null");
     }
 
     /**
-     * Gets the path for the python interpreter.
+     * Gets the path for the Python interpreter.
      *
-     * @param version The python version.
-     * @return The path to the python interpreter.
+     * Uses different logic based on the `useUv` flag.
+     * - If useUv is true: attempts to find and install the specified Python version.
+     * - If useUv is false: tries to find a system-wide Python interpreter.
+     *
+     * @param version The desired Python version (may be null).
+     * @return The path to the Python interpreter.
+     * @throws KestraRuntimeException If a suitable interpreter cannot be found or installed.
      */
     public String getPythonPath(final String version) {
-        Optional<String> pythonPath = findPython(version);
-        if (pythonPath.isEmpty()) {
-            installPython(version);
-            pythonPath = findPython(version);
-        }
-        return pythonPath.orElseThrow(() -> new KestraRuntimeException("Could not find or install Python '" + version + "'path"));
+        return packageManagerType.getPythonPath(this, version);
     }
+
 
     /**
      * Finds the version of the local Python installation.
@@ -68,6 +74,24 @@ public class PythonDependenciesResolver {
      *         if Python is installed and the version can be determined; otherwise, an empty {@link Optional}
      */
     public Optional<String> findLocalPythonVersion() {
+        if (packageManagerType == PackageManagerType.PIP) {
+            logger.debug("Find local python version using system python");
+            try {
+                ExecExitStatus execExitStatus = execCommandAndGetStdOut(List.of("python3", "--version"));
+                if (execExitStatus.isSuccess()) {
+                    return execExitStatus.stdOuts().stream().findFirst()
+                        .map(version -> version.replaceFirst("Python ", ""));
+                }
+                return Optional.empty();
+            } catch (IOException | InterruptedException e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                logger.debug("Failed to get python version", e);
+                return Optional.empty();
+            }
+        }
+
         Optional<String> python = findPython(null);
         if (python.isPresent()) {
             logger.debug("Find local python version");
@@ -145,64 +169,25 @@ public class PythonDependenciesResolver {
         );
     }
 
-    private static String getRequirementTxtFilename(String hash) {
+    protected static String getRequirementTxtFilename(String hash) {
         // Prefix with 'hash' to avoid file name collision
         return hash + "-" + ResolvedPythonPackages.REQUIREMENTS_TXT;
     }
 
     public ResolvedPythonPackages getPythonLibs(final String version, final String hash, final List<String> requirements) throws IOException {
-        final String pythonPath = getPythonPath(version);
         final Path pythonLibDir = workingDir.resolve(Path.of(WORKING_DIR_ADDITIONAL_PYTHON_LIB));
 
-        Path in = createRequirementInFileAndGetPath(version, hash, requirements);
-
-        logger.debug("Compiling dependencies");
-        Path req = workingDir.createFile(getRequirementTxtFilename(hash));
-
-        try {
-            execCommandAndGetStdOut(
-                List.of(getUvCmd(), "pip", "compile",
-                    "--quiet",
-                    "--no-color",
-                    "--no-config",
-                    "--no-header",
-                    "--strip-extras",
-                    "--output-file", req.toString(),
-                    "--python", pythonPath,
-                    "--cache-dir", getUvCacheDir(),
-                    in.toString()
-                )
-            );
-        } catch (IOException | InterruptedException e) {
-            if (e instanceof InterruptedException)  {
-                Thread.currentThread().interrupt();
+        if (!packageManagerType.isAvailable(this)) {
+            if (packageManagerType == PackageManagerType.UV) {
+                logger.warn("UV not available, falling back to PIP");
+                PackageManagerType fallback = PackageManagerType.PIP;
+                String pythonPath = fallback.getPythonPath(this, version);
+                return fallback.installPackages(this, pythonPath, version, hash, requirements, pythonLibDir);
             }
-            throw new KestraRuntimeException("Failed to wait for 'uv pip compile' command. Error " + e.getMessage());
         }
 
-        logger.debug("Installing packages");
-        try {
-            execCommandAndGetStdOut(
-                List.of(getUvCmd(), "pip", "install",
-                    "--quiet",
-                    "--no-color",
-                    "--no-config",
-                    "--link-mode", "copy",
-                    "--reinstall",
-                    "--index-strategy", "unsafe-best-match",
-                    "--target=" + pythonLibDir,
-                    "--requirement=" + req,
-                    "--python", pythonPath,
-                    "--cache-dir", getUvCacheDir()
-                )
-            );
-        } catch (IOException | InterruptedException e) {
-            if (e instanceof InterruptedException)  {
-                Thread.currentThread().interrupt();
-            }
-            throw new KestraRuntimeException("Failed to wait for uv pip install command. Error " + e.getMessage());
-        }
-        return new ResolvedPythonPackages(pythonLibDir, req, hash, version);
+        String pythonPath = getPythonPath(version);
+        return packageManagerType.installPackages(this, pythonPath, version, hash, requirements, pythonLibDir);
     }
 
     public Path createRequirementInFileAndGetPath(String version, String hash, List<String> requirements) throws IOException {
@@ -242,7 +227,7 @@ public class PythonDependenciesResolver {
         return inReqList;
     }
 
-    private ExecExitStatus execCommandAndGetStdOut(List<String> command) throws IOException, InterruptedException {
+    protected ExecExitStatus execCommandAndGetStdOut(List<String> command) throws IOException, InterruptedException {
         return execCommandAndGetStdOut(command, null);
     }
 
@@ -272,7 +257,7 @@ public class PythonDependenciesResolver {
         return new ExecExitStatus(exitCode, outs);
     }
 
-    private String getUvCmd() {
+    protected String getUvCmd() {
         if (this.uvCmd != null) {
             return this.uvCmd;
         }
@@ -336,18 +321,24 @@ public class PythonDependenciesResolver {
                 }
             }
         }
+
         if (version != null) {
             logger.debug("Use uv: {}", version);
+            return this.uvCmd;
+        } else {
+            throw new KestraRuntimeException(
+                "'uv' command could not be found or installed. " +
+                "Please ensure 'uv' is available in PATH or installable on this worker."
+            );
         }
-        return this.uvCmd;
     }
 
-    private String getUvVersion(String uvCmd) throws IOException, InterruptedException {
+    protected String getUvVersion(String uvCmd) throws IOException, InterruptedException {
         ExecExitStatus execStatus = execCommandAndGetStdOut(List.of(uvCmd, "--version"), null);
         return execStatus.isSuccess() ? execStatus.stdOuts.getFirst() : null;
     }
 
-    private boolean installPython(String version) {
+    protected boolean installPython(String version) {
         logger.debug("Installing Python '{}' environment", version);
 
         // Only use managed Python installations; never use system Python installations
@@ -381,7 +372,7 @@ public class PythonDependenciesResolver {
         return exec.isSuccess();
     }
 
-    private Optional<String> findPython(final String version) {
+    protected Optional<String> findPython(final String version) {
 
         List<String> command;
         if (version != null) {
@@ -428,7 +419,7 @@ public class PythonDependenciesResolver {
         return localCacheDir.resolve("python").toString();
     }
 
-    private String getUvCacheDir() {
+    protected String getUvCacheDir() {
         return localCacheDir.resolve("uv").toString();
     }
 

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManager.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManager.java
@@ -33,6 +33,13 @@ public class PythonEnvironmentManager {
     private final RunContext runContext;
     private final boolean isDependencyCacheEnabled;
     private final String pythonVersion;
+    private final PackageManagerType packageManager;
+
+    public PythonEnvironmentManager(final RunContext runContext,
+                                final PythonBasedPlugin plugin) throws IllegalVariableEvaluationException {
+        this(runContext, plugin, PackageManagerType.UV);
+    }
+
 
     /**
      * Creates a new {@link PythonBasedPlugin} instance.
@@ -40,18 +47,25 @@ public class PythonEnvironmentManager {
      * @param plugin The plugin for which the environment will be managed.
      */
     public PythonEnvironmentManager(final RunContext runContext,
-                                    final PythonBasedPlugin plugin) throws IllegalVariableEvaluationException {
+                                    final PythonBasedPlugin plugin, final PackageManagerType packageManager) throws IllegalVariableEvaluationException {
         this.plugin = plugin;
         this.runContext = runContext;
         this.isDependencyCacheEnabled = runContext.render(this.plugin.getDependencyCacheEnabled()).as(Boolean.class).orElse(true);
         this.pythonVersion = runContext.render(this.plugin.getPythonVersion()).as(String.class).orElse(null);
+        this.packageManager = packageManager != null ? packageManager : PackageManagerType.PIP;
     }
 
     public ResolvedPythonEnvironment setup(final Property<String> containerImage, final TaskRunner<?> taskRunner, final RunnerType runnerType) throws IllegalVariableEvaluationException, IOException {
         List<String> requirements = new ArrayList<>(runContext.render(plugin.getDependencies()).asList(String.class));
 
         final Path localCacheDir = getLocalCacheDir();
-        final PythonDependenciesResolver resolver = new PythonDependenciesResolver(runContext.logger(), runContext.workingDir(), localCacheDir);
+
+        final PythonDependenciesResolver resolver = new PythonDependenciesResolver(
+            runContext.logger(),
+            runContext.workingDir(),
+            localCacheDir,
+            packageManager
+        );
 
         final String targetPythonVersion = getTargetPythonVersion(containerImage, taskRunner, runnerType)
             .or(resolver::findLocalPythonVersion)

--- a/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/CommandsTest.java
+++ b/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/CommandsTest.java
@@ -12,6 +12,7 @@ import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.kestra.plugin.scripts.python.internals.PackageManagerType;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.apache.commons.io.IOUtils;
@@ -70,5 +71,79 @@ class CommandsTest {
         TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("hello there!"));
         receive.blockLast();
         assertThat(logs.stream().filter(logEntry -> logEntry.getMessage() != null && logEntry.getMessage().contains("hello there!")).count(), is(1L));
+    }
+
+    @Test
+    void testPipPackageManager() throws Exception {
+        List<LogEntry> logs = new ArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+
+        String script = "import requests, idna; print(f'requests: {requests.__version__}, idna: {idna.__version__}')";
+        URI put = storageInterface.put(TenantService.MAIN_TENANT, null, new URI("/file/storage/pip_test.py"), IOUtils.toInputStream(script, StandardCharsets.UTF_8));
+
+        Commands task = Commands.builder()
+            .id("test-pip")
+            .type(Commands.class.getName())
+            .commands(Property.ofValue(List.of("python " + put.toString())))
+            .packageManager(Property.ofValue(PackageManagerType.PIP))
+            .dependencies(Property.ofValue(List.of("requests", "idna")))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+        ScriptOutput run = task.run(runContext);
+
+        assertThat(run.getExitCode(), is(0));
+        TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("requests:"));
+        receive.blockLast();
+    }
+
+    @Test
+    void testUvPackageManager() throws Exception {
+        List<LogEntry> logs = new ArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+
+        String script = "import requests; print(f'requests (UV): {requests.__version__}')";
+        URI put = storageInterface.put(TenantService.MAIN_TENANT, null, new URI("/file/storage/uv_test.py"), IOUtils.toInputStream(script, StandardCharsets.UTF_8));
+
+        Commands task = Commands.builder()
+            .id("test-uv")
+            .type(Commands.class.getName())
+            .commands(Property.ofValue(List.of("python " + put.toString())))
+            .dependencies(Property.ofValue(List.of("requests")))
+            .packageManager(Property.ofValue(PackageManagerType.UV))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+        ScriptOutput run = task.run(runContext);
+
+        assertThat(run.getExitCode(), is(0));
+        TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("uv test worked"));
+        receive.blockLast();
+    }
+
+    @Test
+    void testBackwardCompatibility() throws Exception {
+        List<LogEntry> logs = new ArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+
+        String script = "import requests; print('backward compatibility works', requests.__version__)";
+        URI put = storageInterface.put(TenantService.MAIN_TENANT, null, new URI("/file/storage/compat_test.py"), IOUtils.toInputStream(script, StandardCharsets.UTF_8));
+
+        Commands task = Commands.builder()
+            .id("test-compat")
+            .type(Commands.class.getName())
+            .commands(Property.ofValue(List.of("python " + put.toString())))
+            .dependencies(Property.ofValue(List.of("requests")))
+            .dependencyCacheEnabled(Property.ofValue(false))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+        ScriptOutput run = task.run(runContext);
+
+        assertThat(run.getExitCode(), is(0));
+        TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("backward compatibility works"));
+        receive.blockLast();
+
+        assertThat(logs.stream().anyMatch(log -> log.getMessage() != null && log.getMessage().contains("backward compatibility works")), is(true));
     }
 }


### PR DESCRIPTION
### What changes are being made and why?


This PR adds support for using uv as an alternative to classic pip/venv for Python dependency management in Kestra's Python plugins. Adds a `packageManager` property to allow users to select between uv and classic pip/venv.
Updates the environment and dependency resolver logic to support fallback.
Ensures backward compatibility by defaulting to classic pip/venv if `packageManager` is not set.
Improves error handling and test coverage for both modes.


---

### How the changes have been QAed?

Example flow using `packageManager: UV`:
```yaml
id: python_uv_example
namespace: test

tasks:
  - id: python
    type: io.kestra.plugin.scripts.python.Commands
    packageManager: UV
    inputFiles:
      main.py: |
        import sys
        print("Hello from uv!", sys.version)
    commands:
      - python main.py
```
Example flow using classic pip/venv:
```yaml
id: python_classic_example
namespace: test

tasks:
  - id: python
    type: io.kestra.plugin.scripts.python.Commands
    packageManager: PIP
    inputFiles:
      main.py: |
        import sys
        print("Hello from classic pip!", sys.version)
    commands:
      - python main.py
```

