### PR TITLE
chore(sanitychecks): add an assert task to validate the task behaviour

### DIFF
--- a/plugin-script-python/src/test/resources/sanity-checks/all_python.yaml
+++ b/plugin-script-python/src/test/resources/sanity-checks/all_python.yaml
@@ -139,4 +139,4 @@ tasks:
     - "{{ outputs.python_script_process.exitCode == 0 }}"
     - "{{ outputs.python_script_logs.exitCode == 0 }}"
     - "{{ outputs.python_script_metrics.exitCode == 0 }}"
-    - "{{ outputs.python_commands_etl_outputs.outputFiles != '' }}"
+    - "{{ outputs.python_commands_etl_outputs.outputFiles['processed_orders.csv'] != null }}"

--- a/plugin-script-python/src/test/resources/sanity-checks/all_python.yaml
+++ b/plugin-script-python/src/test/resources/sanity-checks/all_python.yaml
@@ -129,3 +129,14 @@ tasks:
       DISCOUNT_AMOUNT: "{{ inputs.discount_amount }}"
     commands:
       - python main.py
+
+  - id: assert
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+    - "{{ outputs.python_script.exitCode == 0 }}"
+    - "{{ outputs.python_script_process.exitCode == 0 }}"
+    - "{{ outputs.python_commands.exitCode == 0 }}"
+    - "{{ outputs.python_script_process.exitCode == 0 }}"
+    - "{{ outputs.python_script_logs.exitCode == 0 }}"
+    - "{{ outputs.python_script_metrics.exitCode == 0 }}"
+    - "{{ outputs.python_commands_etl_outputs.outputFiles != '' }}"


### PR DESCRIPTION
### What changes are being made and why?

Add an assert task to validate the task behaviour for `io.kestra.plugin.scripts.python.Commands` and `io.kestra.plugin.scripts.python.Script` 