### PR TITLE
refactor: replace @slf4j with runContext.logger()

### DIFF
--- a/plugin-script-python/src/main/java/io/kestra/core/tasks/scripts/Python.java
+++ b/plugin-script-python/src/main/java/io/kestra/core/tasks/scripts/Python.java
@@ -8,14 +8,12 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.plugin.scripts.python.internals.PackageManagerType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
@@ -102,7 +100,6 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
         )
     }
 )
-@Slf4j
 @Deprecated
 public class Python extends AbstractBash implements RunnableTask<ScriptOutput> {
     @Builder.Default

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonDependenciesResolver.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonDependenciesResolver.java
@@ -2,7 +2,6 @@ package io.kestra.plugin.scripts.python.internals;
 
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.runners.WorkingDir;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
@@ -23,7 +22,6 @@ import java.util.function.Function;
 /**
  * Service for resolving python and installing packages.
  */
-@Slf4j
 public class PythonDependenciesResolver {
 
     private static final String HOME_ENV = System.getenv("HOME");


### PR DESCRIPTION
This PR removes unused `@Slf4j` annotations and uses execution-specific `runContext.logger()` where applicable. This aligns the plugin with project-wide logging conventions.

### What changes are being made and why?

- Removed unused `@Slf4j` annotations


Related to kestra-io/kestra#12770

***

### How the changes have been QAed?

✅ Code compiles with no errors or warnings
✅ No functional changes - refactoring only