### PR TITLE
feat(shell): introduce ScriptTrigger and CommandsTrigger

### DIFF
--- a/plugin-script-shell/build.gradle
+++ b/plugin-script-shell/build.gradle
@@ -16,4 +16,7 @@ dependencies {
     implementation project(':plugin-script')
 
     testImplementation project(':plugin-script').sourceSets.test.output
+
+    testImplementation group: "io.kestra", name: "scheduler", version: kestraVersion
+    testImplementation group: "io.kestra", name: "worker", version: kestraVersion
 }

--- a/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/CommandsTrigger.java
+++ b/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/CommandsTrigger.java
@@ -1,0 +1,241 @@
+package io.kestra.plugin.scripts.shell;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTaskException;
+import io.kestra.core.models.tasks.runners.TaskException;
+import io.kestra.core.models.triggers.*;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.core.runner.Process;
+import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(title = "Trigger a flow when Shell commands match a condition.")
+@Plugin(
+    examples = {
+        @Example(
+            title = "Trigger when commands fail with an implicit error (exit 1).",
+            full = true,
+            code = """
+                id: commands_trigger
+                namespace: company.team
+
+                triggers:
+                  - id: commands_failure
+                    type: io.kestra.plugin.scripts.shell.CommandsTrigger
+                    interval: PT10S
+                    exitCondition: "exit 1"
+                    edge: true
+                    containerImage: ubuntu
+                    commands:
+                      - cat /path/that/does/not/exist
+
+                tasks:
+                  - id: log
+                    type: io.kestra.plugin.core.log.Log
+                    message: "Triggered with exitCode={{ trigger.exitCode }} (condition={{ trigger.condition }})"
+                """
+        )
+    }
+)
+public class CommandsTrigger extends AbstractTrigger
+    implements PollingTriggerInterface, TriggerOutput<CommandsTrigger.Output> {
+
+    private static final String DEFAULT_IMAGE = "ubuntu";
+
+    @Schema(
+        title = "Docker image used to execute the commands.",
+        description = """
+            Container image used by the underlying Commands task to run shell commands.
+            Defaults to 'ubuntu'.
+            """
+    )
+    @Builder.Default
+    protected Property<String> containerImage = Property.ofValue(DEFAULT_IMAGE);
+
+    @Schema(
+        title = "Shell commands to execute.",
+        description = "Commands executed on each poll (same semantics as the Shell Commands task)."
+    )
+    @NotNull
+    protected Property<List<String>> commands;
+
+    @Schema(
+        title = "Condition to match.",
+        description = """
+            Condition evaluated after each commands execution. The trigger emits an event only when this condition matches.
+
+            Supported forms:
+            - 'exit N' (example: 'exit 1'): matches when the process exit code equals N.
+            - Any other string: treated as a regex (or substring if regex is invalid) matched against:
+              - the task 'vars' (when commands emit ::{"outputs":...}::),
+              - and error logs when the task fails (TaskException).
+            """
+    )
+    @NotNull
+    protected Property<String> exitCondition;
+
+    @Schema(
+        title = "Check interval",
+        description = "Interval between polling evaluations."
+    )
+    @Builder.Default
+    private final Duration interval = Duration.ofSeconds(60);
+
+    @Schema(
+        title = "Edge trigger mode.",
+        description = """
+            If true, the trigger emits only on a transition from 'not matching' to 'matching' (anti-spam).
+            If false, the trigger emits on every poll where the condition matches.
+            """
+    )
+    @Builder.Default
+    protected Property<Boolean> edge = Property.ofValue(true);
+
+    @Builder.Default
+    @Getter(AccessLevel.NONE)
+    private final AtomicBoolean lastMatched = new AtomicBoolean(false);
+
+    @Override
+    public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws Exception {
+        RunContext runContext = conditionContext.getRunContext();
+        boolean rEdge = runContext.render(this.edge).as(Boolean.class).orElse(true);
+
+        Output out = runOnce(runContext);
+        boolean matched = matchesCondition(out);
+
+        boolean emit = rEdge
+            ? (!lastMatched.getAndSet(matched) && matched)
+            : matched;
+
+        if (!emit) {
+            return Optional.empty();
+        }
+
+        return Optional.of(TriggerService.generateExecution(this, conditionContext, context, out));
+    }
+
+    private Output runOnce(RunContext runContext) throws Exception {
+        Commands task = Commands.builder()
+            .taskRunner(Process.instance())
+            .containerImage(this.containerImage)
+            .commands(this.commands)
+            .build();
+
+        String renderedCondition = runContext.render(this.exitCondition).as(String.class).orElse("");
+
+        try {
+            ScriptOutput taskOutput = task.run(runContext);
+            Integer exitCode = safeExitCode(taskOutput);
+            Map<String, Object> vars = safeVars(taskOutput);
+
+            return new Output(Instant.now(), renderedCondition, exitCode, vars, null);
+        } catch (RunnableTaskException e) {
+            ExtractedFailure failure = extractFailure(e);
+            return new Output(Instant.now(), renderedCondition, failure.exitCode, null, failure.logs);
+        }
+    }
+
+    private boolean matchesCondition(Output out) {
+        String cond = out.getCondition() == null ? "" : out.getCondition().trim();
+
+        Matcher exitMatcher = Pattern.compile("^\\s*exit\\s+(\\d+)\\s*$", Pattern.CASE_INSENSITIVE).matcher(cond);
+        if (exitMatcher.matches()) {
+            int expected = Integer.parseInt(exitMatcher.group(1));
+            return out.getExitCode() != null && out.getExitCode() == expected;
+        }
+
+        String haystack = buildHaystack(out);
+        if (haystack.isEmpty() || cond.isEmpty()) {
+            return false;
+        }
+
+        try {
+            return Pattern.compile(cond).matcher(haystack).find();
+        } catch (Exception invalidRegex) {
+            return haystack.contains(cond);
+        }
+    }
+
+    private String buildHaystack(Output out) {
+        StringBuilder sb = new StringBuilder();
+
+        if (out.getVars() != null && !out.getVars().isEmpty()) {
+            sb.append(out.getVars()).append("\n");
+        }
+        if (out.getLogs() != null && !out.getLogs().isBlank()) {
+            sb.append(out.getLogs()).append("\n");
+        }
+
+        return sb.toString();
+    }
+
+    private Integer safeExitCode(ScriptOutput taskOutput) {
+        try {
+            return taskOutput.getExitCode();
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private Map<String, Object> safeVars(ScriptOutput taskOutput) {
+        try {
+            return taskOutput.getVars();
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private record ExtractedFailure(Integer exitCode, String logs) {
+    }
+
+    private ExtractedFailure extractFailure(RunnableTaskException e) {
+        Integer exitCode = null;
+        String logs = null;
+
+        Throwable cur = e.getCause();
+        while (cur != null) {
+            if (cur instanceof TaskException te) {
+                exitCode = te.getExitCode();
+                try {
+                    logs = te.getLogConsumer() != null ? te.getLogConsumer().toString() : null;
+                } catch (Exception ignored) {
+                }
+                break;
+            }
+            cur = cur.getCause();
+        }
+
+        return new ExtractedFailure(exitCode, logs);
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        private Instant timestamp;
+        private String condition;
+        private Integer exitCode;
+        private Map<String, Object> vars;
+        private String logs;
+    }
+}

--- a/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/ScriptTrigger.java
+++ b/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/ScriptTrigger.java
@@ -1,0 +1,274 @@
+package io.kestra.plugin.scripts.shell;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTaskException;
+import io.kestra.core.models.tasks.runners.TaskException;
+import io.kestra.core.models.triggers.*;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.core.runner.Process;
+import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(title = "Trigger a flow when a Shell script matches a condition.")
+@Plugin(
+    examples = {
+        @Example(
+            title = "Trigger when the script fails with an implicit error (exit 1).",
+            full = true,
+            code = """
+                id: script_trigger
+                namespace: company.team
+
+                triggers:
+                  - id: script_failure
+                    type: io.kestra.plugin.scripts.shell.ScriptTrigger
+                    interval: PT10S
+                    exitCondition: "exit 1"
+                    edge: true
+                    containerImage: ubuntu
+                    script: |
+                      # This command fails because the file doesn't exist, resulting in a non-zero exit code.
+                      cat /path/that/does/not/exist
+
+                tasks:
+                  - id: log
+                    type: io.kestra.plugin.core.log.Log
+                    message: "Triggered with exitCode={{ trigger.exitCode }} (condition={{ trigger.condition }})"
+                """
+        )
+    }
+)
+public class ScriptTrigger extends AbstractTrigger
+    implements PollingTriggerInterface, TriggerOutput<ScriptTrigger.Output> {
+
+    private static final String DEFAULT_IMAGE = "ubuntu";
+
+    @Schema(
+        title = "Docker image used to execute the script.",
+        description = """
+            Container image used by the underlying Script task to run the inline shell script.
+            Defaults to 'ubuntu'.
+            """
+    )
+    @Builder.Default
+    protected Property<String> containerImage = Property.ofValue(DEFAULT_IMAGE);
+
+    @Schema(
+        title = "Inline shell script to execute.",
+        description = """
+            Inline script content (multi-line string). This is the same 'script' concept as the Shell Script task.
+            The script is executed on each poll.
+            """
+    )
+    @NotNull
+    protected Property<String> script;
+
+    @Schema(
+        title = "Condition to match.",
+        description = """
+            Condition evaluated after each script execution. The trigger emits an event only when this condition matches.
+
+            Supported forms:
+            - 'exit N' (example: 'exit 1'): matches when the script exit code equals N.
+            - Any other string: treated as a regex (or substring if regex is invalid) matched against:
+              - the task 'vars' (when the script emits ::{"outputs":...}::),
+              - and error logs when the task fails (TaskException).
+            """
+    )
+    @NotNull
+    protected Property<String> exitCondition;
+
+    @Schema(
+        title = "Check interval",
+        description = """
+            Interval between polling evaluations. The scheduler uses this interval to compute the next evaluation date.
+            """
+    )
+    @Builder.Default
+    private final Duration interval = Duration.ofSeconds(60);
+
+    @Schema(
+        title = "Edge trigger mode.",
+        description = """
+            If true, the trigger emits only on a transition from 'not matching' to 'matching' (anti-spam).
+            If false, the trigger emits on every poll where the condition matches.
+            """
+    )
+    @Builder.Default
+    protected Property<Boolean> edge = Property.ofValue(true);
+
+    @Builder.Default
+    @Getter(AccessLevel.NONE)
+    private final AtomicBoolean lastMatched = new AtomicBoolean(false);
+
+    @Override
+    public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws Exception {
+        RunContext runContext = conditionContext.getRunContext();
+        boolean rEdge = runContext.render(this.edge).as(Boolean.class).orElse(true);
+
+        Output out = runOnce(runContext);
+
+        // USE exitCondition to decide whether to emit
+        boolean matched = matchesCondition(out);
+
+        boolean emit = rEdge
+            ? (!lastMatched.getAndSet(matched) && matched)
+            : matched;
+
+        if (!emit) {
+            return Optional.empty();
+        }
+
+        return Optional.of(TriggerService.generateExecution(this, conditionContext, context, out));
+    }
+
+    private Output runOnce(RunContext runContext) throws Exception {
+        Script task = Script.builder()
+            .taskRunner(Process.instance())
+            .containerImage(this.containerImage)
+            .script(this.script)
+            .build();
+
+        String rExitCondition = runContext.render(this.exitCondition).as(String.class).orElse("");
+
+        try {
+            ScriptOutput taskOutput = task.run(runContext);
+            Integer exitCode = safeExitCode(taskOutput);
+
+            // vars are the only reliable structured "result" we can read on success
+            Map<String, Object> vars = safeVars(taskOutput);
+
+            return new Output(Instant.now(), rExitCondition, exitCode, vars, null);
+        } catch (RunnableTaskException e) {
+            ExtractedFailure failure = extractFailure(e);
+            return new Output(Instant.now(), rExitCondition, failure.exitCode, null, failure.logs);
+        }
+    }
+
+    private boolean matchesCondition(Output out) {
+        String cond = out.getCondition() == null ? "" : out.getCondition().trim();
+
+        // 1) exit N
+        Matcher exitMatcher = Pattern.compile("^\\s*exit\\s+(\\d+)\\s*$", Pattern.CASE_INSENSITIVE).matcher(cond);
+        if (exitMatcher.matches()) {
+            int expected = Integer.parseInt(exitMatcher.group(1));
+            return out.getExitCode() != null && out.getExitCode() == expected;
+        }
+
+        // 2) otherwise: regex (fallback contains) on vars + logs
+        String haystack = buildHaystack(out);
+        if (haystack.isEmpty() || cond.isEmpty()) {
+            return false;
+        }
+
+        try {
+            return Pattern.compile(cond).matcher(haystack).find();
+        } catch (Exception invalidRegex) {
+            return haystack.contains(cond);
+        }
+    }
+
+    private String buildHaystack(Output out) {
+        StringBuilder sb = new StringBuilder();
+
+        if (out.getVars() != null && !out.getVars().isEmpty()) {
+            sb.append(out.getVars()).append("\n");
+        }
+        if (out.getLogs() != null && !out.getLogs().isBlank()) {
+            sb.append(out.getLogs()).append("\n");
+        }
+
+        return sb.toString();
+    }
+
+    private Integer safeExitCode(ScriptOutput taskOutput) {
+        try {
+            return taskOutput.getExitCode();
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private Map<String, Object> safeVars(ScriptOutput taskOutput) {
+        try {
+            return taskOutput.getVars();
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private record ExtractedFailure(Integer exitCode, String logs) {}
+
+    private ExtractedFailure extractFailure(RunnableTaskException e) {
+        Integer exitCode = null;
+        String logs = null;
+
+        Throwable cur = e.getCause();
+        while (cur != null) {
+            if (cur instanceof TaskException te) {
+                exitCode = te.getExitCode();
+                // Best-effort: TaskException carries a log consumer; toString() usually contains aggregated logs.
+                try {
+                    logs = te.getLogConsumer() != null ? te.getLogConsumer().toString() : null;
+                } catch (Exception ignored) {}
+                break;
+            }
+            cur = cur.getCause();
+        }
+
+        return new ExtractedFailure(exitCode, logs);
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        private Instant timestamp;
+
+        @Schema(
+            title = "Rendered condition.",
+            description = "Rendered value of the exitCondition property for this poll."
+        )
+        private String condition;
+
+        @Schema(
+            title = "Script exit code.",
+            description = "Exit code returned by the shell process (may be null if not available)."
+        )
+        private Integer exitCode;
+
+        @Schema(
+            title = "Script vars.",
+            description = """
+                Vars produced by the task (e.g. via ::{"outputs":{...}}:: convention). This is the main structured
+                way to evaluate non-exit conditions on successful runs.
+                """
+        )
+        private Map<String, Object> vars;
+
+        @Schema(
+            title = "Captured logs (best effort).",
+            description = "Captured error logs when the script fails (best effort, depends on the runner)."
+        )
+        private String logs;
+    }
+}

--- a/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/CommandsTriggerTest.java
+++ b/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/CommandsTriggerTest.java
@@ -1,0 +1,232 @@
+package io.kestra.plugin.scripts.shell;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.FlowListeners;
+import io.kestra.core.utils.Await;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.jdbc.runner.JdbcScheduler;
+import io.kestra.plugin.core.debug.Return;
+import io.kestra.scheduler.AbstractScheduler;
+import io.kestra.worker.DefaultWorker;
+import io.micronaut.context.ApplicationContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+@KestraTest
+class CommandsTriggerTest {
+    @Inject
+    protected ApplicationContext applicationContext;
+
+    @Inject
+    protected FlowListeners flowListenersService;
+
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    protected QueueInterface<Execution> executionQueue;
+
+    @Test
+    void commandsTrigger_shouldTriggerOnImplicitFailureExit1() throws Exception {
+        FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
+
+        CommandsTrigger trigger = CommandsTrigger.builder()
+            .id("commands-trigger")
+            .type(CommandsTrigger.class.getName())
+            .interval(Duration.ofSeconds(1))
+            .exitCondition(Property.ofValue("exit 1"))
+            .edge(Property.ofValue(true))
+            .containerImage(Property.ofValue("ubuntu"))
+            .commands(Property.ofValue(List.of(
+                // Implicit failure -> non-zero exit code
+                "cat /path/that/does/not/exist"
+            )))
+            .build();
+
+        Flow testFlow = Flow.builder()
+            .id("commands-trigger-flow")
+            .namespace("io.kestra.tests")
+            .revision(1)
+            .tasks(Collections.singletonList(Return.builder()
+                .id("log-trigger-vars")
+                .type(Return.class.getName())
+                .format(Property.ofValue("exitCode={{ trigger.exitCode }}, condition={{ trigger.condition }}"))
+                .build()))
+            .triggers(Collections.singletonList(trigger))
+            .build();
+
+        FlowWithSource flow = FlowWithSource.of(testFlow, null);
+        doReturn(List.of(flow)).when(flowListenersServiceSpy).flows();
+
+        CountDownLatch queueCount = new CountDownLatch(1);
+        AtomicReference<Execution> lastExecution = new AtomicReference<>();
+
+        Flux<Execution> receive = TestsUtils.receive(executionQueue, execution -> {
+            if (execution.getLeft().getFlowId().equals("commands-trigger-flow")) {
+                lastExecution.set(execution.getLeft());
+                queueCount.countDown();
+            }
+        });
+
+        DefaultWorker worker = applicationContext.createBean(DefaultWorker.class, IdUtils.create(), 8, null);
+        AbstractScheduler scheduler = new JdbcScheduler(applicationContext, flowListenersServiceSpy);
+
+        try {
+            worker.run();
+            scheduler.run();
+
+            Thread.sleep(Duration.ofSeconds(2).toMillis());
+
+            boolean await = queueCount.await(20, TimeUnit.SECONDS);
+            assertThat("CommandsTrigger should execute", await, is(true));
+
+            try {
+                Await.until(
+                    () -> lastExecution.get() != null,
+                    Duration.ofMillis(100),
+                    Duration.ofSeconds(2)
+                );
+            } catch (TimeoutException e) {
+                throw new AssertionError("Execution was not captured within 2 seconds", e);
+            }
+
+            Execution execution = lastExecution.get();
+            assertThat(execution, notNullValue());
+
+            Map<String, Object> triggerVars = execution.getTrigger().getVariables();
+            assertThat("condition should be present", triggerVars.get("condition"), is("exit 1"));
+            assertThat("exitCode should be present", triggerVars.get("exitCode"), notNullValue());
+            assertThat("exitCode should be 1", triggerVars.get("exitCode"), is(1));
+            assertThat("timestamp should be present", triggerVars.get("timestamp"), notNullValue());
+        } finally {
+            try {
+                worker.shutdown();
+            } catch (Exception ignored) {
+            }
+            try {
+                scheduler.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                receive.blockLast();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    @Test
+    void commandsTrigger_shouldTriggerOnStdoutMatchUsingStructuredOutputs() throws Exception {
+        FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
+
+        CommandsTrigger trigger = CommandsTrigger.builder()
+            .id("commands-stdout-match-trigger")
+            .type(CommandsTrigger.class.getName())
+            .interval(Duration.ofSeconds(1))
+            .exitCondition(Property.ofValue("toto"))
+            .edge(Property.ofValue(true))
+            .containerImage(Property.ofValue("ubuntu"))
+            .commands(Property.ofValue(List.of(
+                "set -e",
+                "echo \"toto\" > toto.txt",
+                "ls -l",
+                // Emit structured outputs so the trigger has something deterministic to evaluate
+                "echo '::{\"outputs\":{\"listing\":\"toto\"}}::'"
+            )))
+            .build();
+
+        Flow testFlow = Flow.builder()
+            .id("commands-stdout-match-flow")
+            .namespace("io.kestra.tests")
+            .revision(1)
+            .tasks(Collections.singletonList(Return.builder()
+                .id("log-trigger-vars")
+                .type(Return.class.getName())
+                .format(Property.ofValue("exitCode={{ trigger.exitCode }}, condition={{ trigger.condition }}"))
+                .build()))
+            .triggers(Collections.singletonList(trigger))
+            .build();
+
+        FlowWithSource flow = FlowWithSource.of(testFlow, null);
+        doReturn(List.of(flow)).when(flowListenersServiceSpy).flows();
+
+        CountDownLatch queueCount = new CountDownLatch(1);
+        AtomicReference<Execution> lastExecution = new AtomicReference<>();
+
+        Flux<Execution> receive = TestsUtils.receive(executionQueue, execution -> {
+            if (execution.getLeft().getFlowId().equals("commands-stdout-match-flow")) {
+                lastExecution.set(execution.getLeft());
+                queueCount.countDown();
+            }
+        });
+
+        DefaultWorker worker = applicationContext.createBean(DefaultWorker.class, IdUtils.create(), 8, null);
+        AbstractScheduler scheduler = new JdbcScheduler(applicationContext, flowListenersServiceSpy);
+
+        try {
+            worker.run();
+            scheduler.run();
+
+            Thread.sleep(Duration.ofSeconds(2).toMillis());
+
+            boolean await = queueCount.await(20, TimeUnit.SECONDS);
+            assertThat("CommandsTrigger should execute", await, is(true));
+
+            try {
+                Await.until(
+                    () -> lastExecution.get() != null,
+                    Duration.ofMillis(100),
+                    Duration.ofSeconds(2)
+                );
+            } catch (TimeoutException e) {
+                throw new AssertionError("Execution was not captured within 2 seconds", e);
+            }
+
+            Execution execution = lastExecution.get();
+            assertThat(execution, notNullValue());
+
+            Map<String, Object> triggerVars = execution.getTrigger().getVariables();
+            assertThat("condition should be present", triggerVars.get("condition"), is("toto"));
+            assertThat("exitCode should be present", triggerVars.get("exitCode"), notNullValue());
+            assertThat("exitCode should be 0", triggerVars.get("exitCode"), is(0));
+            assertThat("timestamp should be present", triggerVars.get("timestamp"), notNullValue());
+
+            Object vars = triggerVars.get("vars");
+            assertThat("vars should be present (best effort)", vars, notNullValue());
+        } finally {
+            try {
+                worker.shutdown();
+            } catch (Exception ignored) {
+            }
+            try {
+                scheduler.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                receive.blockLast();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+}

--- a/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/ScriptTriggerTest.java
+++ b/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/ScriptTriggerTest.java
@@ -1,0 +1,237 @@
+package io.kestra.plugin.scripts.shell;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.FlowListeners;
+import io.kestra.core.utils.Await;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.jdbc.runner.JdbcScheduler;
+import io.kestra.plugin.core.debug.Return;
+import io.kestra.scheduler.AbstractScheduler;
+import io.kestra.worker.DefaultWorker;
+import io.micronaut.context.ApplicationContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+@KestraTest
+class ScriptTriggerTest {
+    @Inject
+    protected ApplicationContext applicationContext;
+
+    @Inject
+    protected FlowListeners flowListenersService;
+
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    protected QueueInterface<Execution> executionQueue;
+
+    @Test
+    void scriptTrigger_shouldTriggerOnImplicitFailureExit1() throws Exception {
+        FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
+
+        ScriptTrigger trigger = ScriptTrigger.builder()
+            .id("script-realtime-trigger")
+            .type(ScriptTrigger.class.getName())
+            .interval(Duration.ofSeconds(1))
+            .exitCondition(Property.ofValue("exit 1"))
+            .edge(Property.ofValue(true))
+            .containerImage(Property.ofValue("ubuntu"))
+            .script(Property.ofValue("""
+                # This command fails because the file doesn't exist (implicit non-zero exit code).
+                cat /path/that/does/not/exist
+                """))
+            .build();
+
+        Flow testFlow = Flow.builder()
+            .id("script-realtime-trigger-flow")
+            .namespace("io.kestra.tests")
+            .revision(1)
+            .tasks(Collections.singletonList(Return.builder()
+                .id("log-trigger-vars")
+                .type(Return.class.getName())
+                .format(Property.ofValue("exitCode={{ trigger.exitCode }}, condition={{ trigger.condition }}"))
+                .build()))
+            .triggers(Collections.singletonList(trigger))
+            .build();
+
+        FlowWithSource flow = FlowWithSource.of(testFlow, null);
+        doReturn(List.of(flow)).when(flowListenersServiceSpy).flows();
+
+        CountDownLatch queueCount = new CountDownLatch(1);
+        AtomicReference<Execution> lastExecution = new AtomicReference<>();
+
+        Flux<Execution> receive = TestsUtils.receive(executionQueue, execution -> {
+            if (execution.getLeft().getFlowId().equals("script-realtime-trigger-flow")) {
+                lastExecution.set(execution.getLeft());
+                queueCount.countDown();
+            }
+        });
+
+        DefaultWorker worker = applicationContext.createBean(DefaultWorker.class, IdUtils.create(), 8, null);
+        AbstractScheduler scheduler = new JdbcScheduler(applicationContext, flowListenersServiceSpy);
+
+        try {
+            worker.run();
+            scheduler.run();
+
+            Thread.sleep(Duration.ofSeconds(2).toMillis());
+
+            boolean await = queueCount.await(20, TimeUnit.SECONDS);
+            assertThat("ScriptTrigger should execute", await, is(true));
+
+            try {
+                Await.until(
+                    () -> lastExecution.get() != null,
+                    Duration.ofMillis(100),
+                    Duration.ofSeconds(2)
+                );
+            } catch (TimeoutException e) {
+                throw new AssertionError("Execution was not captured within 2 seconds", e);
+            }
+
+            Execution execution = lastExecution.get();
+            assertThat(execution, notNullValue());
+
+            Map<String, Object> triggerVars = execution.getTrigger().getVariables();
+            assertThat("condition should be present", triggerVars.get("condition"), is("exit 1"));
+            assertThat("exitCode should be present", triggerVars.get("exitCode"), notNullValue());
+            assertThat("exitCode should be 1", triggerVars.get("exitCode"), is(1));
+            assertThat("timestamp should be present", triggerVars.get("timestamp"), notNullValue());
+        } finally {
+            try {
+                worker.shutdown();
+            } catch (Exception ignored) {
+            }
+            try {
+                scheduler.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                receive.blockLast();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    @Test
+    void scriptTrigger_shouldTriggerOnStdoutMatchViaOutputsConvention() throws Exception {
+        FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
+
+        // We intentionally emit a structured output via the ::{"outputs":...}:: convention
+        // so the trigger can match on "toto" without relying on raw stdout capture.
+        ScriptTrigger trigger = ScriptTrigger.builder()
+            .id("script-stdout-match-trigger")
+            .type(ScriptTrigger.class.getName())
+            .interval(Duration.ofSeconds(1))
+            // "toto" is a non-exit condition => treated as regex/substring against vars/logs (per trigger implementation)
+            .exitCondition(Property.ofValue("toto"))
+            .edge(Property.ofValue(true))
+            .containerImage(Property.ofValue("ubuntu"))
+            .script(Property.ofValue("""
+                set -e
+                echo "toto" > toto.txt
+                ls -l
+                # Emit the value in outputs so the trigger can evaluate it reliably
+                echo '::{"outputs":{"listing":"toto"}}::'
+                """))
+            .build();
+
+        Flow testFlow = Flow.builder()
+            .id("script-stdout-match-flow")
+            .namespace("io.kestra.tests")
+            .revision(1)
+            .tasks(Collections.singletonList(Return.builder()
+                .id("log-trigger-vars")
+                .type(Return.class.getName())
+                .format(Property.ofValue("exitCode={{ trigger.exitCode }}, condition={{ trigger.condition }}"))
+                .build()))
+            .triggers(Collections.singletonList(trigger))
+            .build();
+
+        FlowWithSource flow = FlowWithSource.of(testFlow, null);
+        doReturn(List.of(flow)).when(flowListenersServiceSpy).flows();
+
+        CountDownLatch queueCount = new CountDownLatch(1);
+        AtomicReference<Execution> lastExecution = new AtomicReference<>();
+
+        Flux<Execution> receive = TestsUtils.receive(executionQueue, execution -> {
+            if (execution.getLeft().getFlowId().equals("script-stdout-match-flow")) {
+                lastExecution.set(execution.getLeft());
+                queueCount.countDown();
+            }
+        });
+
+        DefaultWorker worker = applicationContext.createBean(DefaultWorker.class, IdUtils.create(), 8, null);
+        AbstractScheduler scheduler = new JdbcScheduler(applicationContext, flowListenersServiceSpy);
+
+        try {
+            worker.run();
+            scheduler.run();
+
+            Thread.sleep(Duration.ofSeconds(2).toMillis());
+
+            boolean await = queueCount.await(20, TimeUnit.SECONDS);
+            assertThat("ScriptTrigger should execute", await, is(true));
+
+            try {
+                Await.until(
+                    () -> lastExecution.get() != null,
+                    Duration.ofMillis(100),
+                    Duration.ofSeconds(2)
+                );
+            } catch (TimeoutException e) {
+                throw new AssertionError("Execution was not captured within 2 seconds", e);
+            }
+
+            Execution execution = lastExecution.get();
+            assertThat(execution, notNullValue());
+
+            Map<String, Object> triggerVars = execution.getTrigger().getVariables();
+            assertThat("condition should be present", triggerVars.get("condition"), is("toto"));
+            assertThat("exitCode should be present", triggerVars.get("exitCode"), notNullValue());
+            assertThat("exitCode should be 0", triggerVars.get("exitCode"), is(0));
+            assertThat("timestamp should be present", triggerVars.get("timestamp"), notNullValue());
+
+            // If your trigger output exposes "vars", we can assert it as well.
+            // Note: this depends on your ScriptTrigger.Output fields being included in Trigger variables.
+            Object vars = triggerVars.get("vars");
+            assertThat("vars should be present (best effort)", vars, notNullValue());
+        } finally {
+            try {
+                worker.shutdown();
+            } catch (Exception ignored) {
+            }
+            try {
+                scheduler.close();
+            } catch (Exception ignored) {
+            }
+            try {
+                receive.blockLast();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes https://github.com/kestra-io/plugin-scripts/issues/315 

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.
- [ ] Update the existing `index.yaml` for the main plugin, and for each new subpackage add a metadata file named exactly after the subpackage (e.g. `s3.yaml` for `io.kestra.plugin.aws.s3`) under `src/main/resources/metadata/`, following the same schema.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).