### PR TITLE
chore(deps): bump kestraVersion to 2.0.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.7.1-SNAPSHOT
-kestraVersion=1.3.0
+kestraVersion=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

Bumps `kestraVersion` from `1.3.0` to `2.0.0-SNAPSHOT` to pick up the `beforeCommands` DEBUG logging fix from the Kestra core.

Related to: https://github.com/kestra-io/kestra/pull/15613
Part-of: https://github.com/kestra-io/kestra/issues/13648