### PR TITLE
test(shell): add outputFilesPebbleExpression test

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.7.2-SNAPSHOT
-kestraVersion=1.3.0
+kestraVersion=1.3.16

--- a/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/ScriptTest.java
+++ b/plugin-script-shell/src/test/java/io/kestra/plugin/scripts/shell/ScriptTest.java
@@ -177,6 +177,29 @@ class ScriptTest {
         );
     }
 
+    @Test
+    void outputFilesPebbleExpression() throws Exception {
+        // Verifies that {{ outputFiles.outfile }} resolves to the correct absolute path inside the script body.
+        // This is the fix for https://github.com/kestra-io/kestra/issues/13765.
+        // Use Property.ofExpression to simulate YAML deserialization (value=null → Pebble rendering runs).
+        Script bash = Script.builder()
+            .id("shell-output-files-pebble-" + UUID.randomUUID())
+            .type(Script.class.getName())
+            .outputFiles(Property.ofValue(List.of("outfile")))
+            .script(Property.ofExpression("echo -n {{ outputFiles.outfile }} > outfile"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, bash, ImmutableMap.of());
+        ScriptOutput run = bash.run(runContext);
+
+        assertThat(run.getExitCode(), is(0));
+        assertThat(run.getOutputFiles().get("outfile").toString(), startsWith("kestra://"));
+        assertThat(
+            new String(storageInterface.get(TenantService.MAIN_TENANT, null, run.getOutputFiles().get("outfile")).readAllBytes()),
+            endsWith("/outfile")
+        );
+    }
+
     private URI internalFiles(String path) throws IOException, URISyntaxException {
         var resource = ScriptTest.class.getClassLoader().getResource("application.yml");
 


### PR DESCRIPTION
:warning: To merge once [this PR](https://github.com/kestra-io/kestra/pull/15758) is backported to `releases/v1.3.x`.

## Summary

Adds `outputFilesPebbleExpression` test to `ScriptTest` to lock in the contract that `{{ outputFiles.name }}` resolves to the correct absolute path inside a Shell `Script` body.

This is the plugin-scripts counterpart to kestra-io/kestra#13765 / kestra-io/kestra#15725 (the core fix). The test will not pass in CI until `kestraVersion` in `gradle.properties` is bumped to a version that includes the core fix.

**Test logic:**
- Declares `outputFiles: ["outfile"]`
- Uses `Property.ofExpression()` for the script body so Pebble rendering runs (simulates YAML deserialization)
- Body: `echo -n {{ outputFiles.outfile }} > outfile` — writes the resolved path to the file
- Asserts the file content ends with `/outfile` (i.e., the Pebble expression resolved to the working-dir path)

## Test plan

- [ ] `./gradlew :plugin-script-shell:test --tests "*ScriptTest.outputFilesPebbleExpression*"` passes after `kestraVersion` bump
- [ ] Existing shell script tests remain green