### PR TITLE
fix(build): fix Gradle 9.5 cross-project sourceSets access

### DIFF
--- a/plugin-script-bun/build.gradle
+++ b/plugin-script-bun/build.gradle
@@ -15,5 +15,5 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-deno/build.gradle
+++ b/plugin-script-deno/build.gradle
@@ -15,5 +15,5 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-go/build.gradle
+++ b/plugin-script-go/build.gradle
@@ -15,7 +15,7 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 
     testImplementation group: "io.kestra", name: "scheduler", version: kestraVersion
     testImplementation group: "io.kestra", name: "worker", version: kestraVersion

--- a/plugin-script-groovy/build.gradle
+++ b/plugin-script-groovy/build.gradle
@@ -17,5 +17,5 @@ dependencies {
 
     api group: 'org.apache.groovy', name: 'groovy-jsr223', version: '5.0.5'
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-jbang/build.gradle
+++ b/plugin-script-jbang/build.gradle
@@ -15,5 +15,5 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-julia/build.gradle
+++ b/plugin-script-julia/build.gradle
@@ -15,5 +15,5 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-jython/build.gradle
+++ b/plugin-script-jython/build.gradle
@@ -17,5 +17,5 @@ dependencies {
 
     implementation group: 'org.python', name: 'jython-standalone', version: '2.7.4'
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-lua/build.gradle
+++ b/plugin-script-lua/build.gradle
@@ -15,5 +15,5 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-nashorn/build.gradle
+++ b/plugin-script-nashorn/build.gradle
@@ -17,5 +17,5 @@ dependencies {
 
     implementation group: 'org.openjdk.nashorn', name: 'nashorn-core', version: '15.7'
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-node/build.gradle
+++ b/plugin-script-node/build.gradle
@@ -15,7 +15,7 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 
     testImplementation group: "io.kestra", name: "scheduler", version: kestraVersion
     testImplementation group: "io.kestra", name: "worker", version: kestraVersion

--- a/plugin-script-perl/build.gradle
+++ b/plugin-script-perl/build.gradle
@@ -15,5 +15,5 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-php/build.gradle
+++ b/plugin-script-php/build.gradle
@@ -15,5 +15,5 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-powershell/build.gradle
+++ b/plugin-script-powershell/build.gradle
@@ -15,5 +15,5 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-python/build.gradle
+++ b/plugin-script-python/build.gradle
@@ -15,7 +15,7 @@ jar {
 dependencies {
     implementation project(':plugin-script')
     implementation("org.apache.commons:commons-compress")
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
     testImplementation group: "io.kestra", name: "scheduler", version: kestraVersion
     testImplementation group: "io.kestra", name: "worker", version: kestraVersion
 }

--- a/plugin-script-r/build.gradle
+++ b/plugin-script-r/build.gradle
@@ -15,5 +15,5 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 }

--- a/plugin-script-ruby/build.gradle
+++ b/plugin-script-ruby/build.gradle
@@ -15,7 +15,7 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 
     testImplementation group: "io.kestra", name: "scheduler", version: kestraVersion
     testImplementation group: "io.kestra", name: "worker", version: kestraVersion

--- a/plugin-script-shell/build.gradle
+++ b/plugin-script-shell/build.gradle
@@ -15,7 +15,7 @@ jar {
 dependencies {
     implementation project(':plugin-script')
 
-    testImplementation project(':plugin-script').sourceSets.test.output
+    testImplementation project(path: ':plugin-script', configuration: 'testOutput')
 
     testImplementation group: "io.kestra", name: "scheduler", version: kestraVersion
     testImplementation group: "io.kestra", name: "worker", version: kestraVersion

--- a/plugin-script/build.gradle
+++ b/plugin-script/build.gradle
@@ -16,3 +16,16 @@ jar {
 test {
     failOnNoDiscoveredTests = false
 }
+
+configurations {
+    testOutput
+}
+
+task testJar(type: Jar) {
+    archiveClassifier = 'tests'
+    from sourceSets.test.output
+}
+
+artifacts {
+    testOutput testJar
+}


### PR DESCRIPTION
## Summary

- Gradle 9.5 no longer allows accessing `.sourceSets` on a `project()` call inside a `dependencies {}` block — it returns `DefaultProjectDependency`, not `Project`
- All 17 submodule `build.gradle` files used `project(':plugin-script').sourceSets.test.output`, causing `BUILD FAILED in 22s` on the dependabot PR [#362](https://github.com/kestra-io/plugin-scripts/pull/362)
- Fix: expose `plugin-script` test classes as a `testJar` artifact under a named `testOutput` configuration; all consumers now reference it via `project(path: ':plugin-script', configuration: 'testOutput')`

## Test plan

- [ ] CI passes on this PR
- [ ] Dependabot PR #362 (bump gradle-wrapper 9.4.1 → 9.5.0) can rebase on this and pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)