### PR TITLE
fix: add missing plugin descriptions for script command triggers for issue #16072

### DIFF
--- a/plugin-script-go/src/main/java/io/kestra/plugin/scripts/go/CommandsTrigger.java
+++ b/plugin-script-go/src/main/java/io/kestra/plugin/scripts/go/CommandsTrigger.java
@@ -43,7 +43,10 @@ import io.kestra.core.models.annotations.PluginProperty;
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
-@Schema(title = "Trigger a flow when Go commands match a condition.")
+@Schema(
+    title = "Trigger a flow when Go commands match a condition.",
+    description = "Polls and triggers a flow by running Go commands within a script container."
+)
 @Plugin(
     examples = {
         @Example(

--- a/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/CommandsTrigger.java
+++ b/plugin-script-node/src/main/java/io/kestra/plugin/scripts/node/CommandsTrigger.java
@@ -31,7 +31,11 @@ import io.kestra.core.models.annotations.PluginProperty;
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
-@Schema(title = "Trigger a flow when Node.js commands match a condition.")
+//  New trigger description
+@Schema(
+    title = "Trigger a flow when Node.js commands match a condition.",
+    description = "Polls and triggers a flow by running Node.js commands within a script container."
+)
 @Plugin(
     examples = {
         @Example(

--- a/plugin-script-ruby/src/main/java/io/kestra/plugin/scripts/ruby/CommandsTrigger.java
+++ b/plugin-script-ruby/src/main/java/io/kestra/plugin/scripts/ruby/CommandsTrigger.java
@@ -34,8 +34,10 @@ import io.kestra.core.models.annotations.PluginProperty;
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
-@Schema(title = "Trigger a flow when Ruby commands match a condition.")
-@Plugin(
+@Schema(
+    title = "Trigger a flow when Ruby commands match a condition.",
+    description = "Polls and triggers a flow by executing inline Ruby scripts and commands."
+)@Plugin(
     examples = {
         @Example(
             title = "Trigger when Ruby command fails.",

--- a/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/CommandsTrigger.java
+++ b/plugin-script-shell/src/main/java/io/kestra/plugin/scripts/shell/CommandsTrigger.java
@@ -32,7 +32,10 @@ import io.kestra.core.models.annotations.PluginProperty;
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
-@Schema(title = "Trigger a flow when Shell commands match a condition.")
+@Schema(
+    title = "Trigger a flow when Shell commands match a condition.",
+    description = "Polls and triggers a flow by running system commands in a shell container."
+)
 @Plugin(
     examples = {
         @Example(


### PR DESCRIPTION
### What changes are being made and why?
This PR fixes missing description text blocks on the frontend UI card components for multiple script-based command triggers.

The class-level @Schema annotations for Go, Node.js, Ruby, and Shell CommandsTrigger implementations were missing the description attribute property. This left their respective cards blank on the Tenant ➔ Triggers ➔ Add view. Adding these fields ensures UI component parity and populates the missing text blocks generated by Kestra's documentation engine.

Closes kestra-io/kestra#16072
---

### How the changes have been QAed?

All four modified plugin modules were validated locally using the Java compiler. The annotations strictly conform to Kestra's core validation layer mapping and use correct properties without introducing regressions or compilation warnings.

Bash
./gradlew compileJava
Result: BUILD SUCCESSFUL across all subprojects.
---

### Contributor Checklist ✅

- [x] I have read and followed the [plugin contribution guidelines](https://kestra.io/docs/plugin-developer-guide/contribution-guidelines)
