### PR TITLE
fix(core): migrate FileSerde to binary ION API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.7.5-SNAPSHOT
-kestraVersion=1.3.16
+kestraVersion=1.3.19

--- a/plugin-script/src/main/java/io/kestra/plugin/scripts/jvm/FileTransform.java
+++ b/plugin-script/src/main/java/io/kestra/plugin/scripts/jvm/FileTransform.java
@@ -73,10 +73,10 @@ public abstract class FileTransform extends AbstractJvmScript implements Runnabl
         );
 
         try (
-            var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)
+            var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)
         ) {
             if (from.startsWith("kestra://")) {
-                try (BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(URI.create(from))), FileSerde.BUFFER_SIZE)) {
+                try (InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(URI.create(from)), FileSerde.BUFFER_SIZE)) {
                     this.finalize(
                         runContext,
                         FileSerde.readAll(inputStream),
@@ -117,7 +117,7 @@ public abstract class FileTransform extends AbstractJvmScript implements Runnabl
         RunContext runContext,
         Flux<Object> flowable,
         ScriptEngineService.CompiledScript scripts,
-        Writer output) throws IOException, ScriptException {
+        OutputStream output) throws IOException, ScriptException {
         Flux<Object> sequential;
 
         if (this.concurrent != null) {

--- a/plugin-script/src/test/java/io/kestra/plugin/scripts/jvm/FileTransformTest.java
+++ b/plugin-script/src/test/java/io/kestra/plugin/scripts/jvm/FileTransformTest.java
@@ -114,34 +114,35 @@ public abstract class FileTransformTest {
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
         FileTransform.Output runOutput = task.run(runContext);
 
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, runOutput.getUri())));
-        List<Object> result = new ArrayList<>();
-        FileSerde.reader(inputStream, result::add);
+        try (InputStream in = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, runOutput.getUri()), FileSerde.BUFFER_SIZE)) {
+            List<Object> result = new ArrayList<>();
+            FileSerde.read(in, result::add);
 
-        AbstractMetricEntry<?> metric = runContext.metrics().get(0);
-        assertThat(metric.getValue(), is((double) size));
+            AbstractMetricEntry<?> metric = runContext.metrics().get(0);
+            assertThat(metric.getValue(), is((double) size));
 
-        assertThat(result.size(), is(size));
-        assertThat(
-            result.stream().filter(o -> ((Map<String, String>) o).get("id").equals("1")).findFirst().orElseThrow(), is(
-                ImmutableMap.of(
-                    "id", "1",
-                    "name", "john",
-                    "email", "john@kestra.io"
-                )
-            )
-        );
-
-        if (size > 1) {
+            assertThat(result.size(), is(size));
             assertThat(
-                result.stream().filter(o -> ((Map<String, String>) o).get("id").equals("2")).findFirst().orElseThrow(), is(
+                result.stream().filter(o -> ((Map<String, String>) o).get("id").equals("1")).findFirst().orElseThrow(), is(
                     ImmutableMap.of(
-                        "id", "2",
-                        "name", "jane",
-                        "email", "jane@kestra.io"
+                        "id", "1",
+                        "name", "john",
+                        "email", "john@kestra.io"
                     )
                 )
             );
+
+            if (size > 1) {
+                assertThat(
+                    result.stream().filter(o -> ((Map<String, String>) o).get("id").equals("2")).findFirst().orElseThrow(), is(
+                        ImmutableMap.of(
+                            "id", "2",
+                            "name", "jane",
+                            "email", "jane@kestra.io"
+                        )
+                    )
+                );
+            }
         }
     }
 
@@ -169,13 +170,14 @@ public abstract class FileTransformTest {
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
         io.kestra.plugin.scripts.jvm.FileTransform.Output runOutput = task.run(runContext);
 
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, runOutput.getUri())));
-        List<Object> result = new ArrayList<>();
-        FileSerde.reader(inputStream, result::add);
+        try (InputStream in = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, runOutput.getUri()), FileSerde.BUFFER_SIZE)) {
+            List<Object> result = new ArrayList<>();
+            FileSerde.read(in, result::add);
 
-        assertThat(result.size(), is(4));
-        assertThat(result, hasItems(1, 2));
-        assertThat(result.get(2), is(map));
-        assertThat(result.get(3), is(Map.of("action", "insert")));
+            assertThat(result.size(), is(4));
+            assertThat(result, hasItems(1, 2));
+            assertThat(result.get(2), is(map));
+            assertThat(result.get(3), is(Map.of("action", "insert")));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Migrate `FileTransform` and its tests from deprecated `Reader`/`Writer`-based `FileSerde` methods to the new `InputStream`/`OutputStream` API
- This enables binary ION serialization for Kestra 2.0 (~20-40% storage reduction)
- Bump `kestraVersion` from `1.3.16` to `1.3.19` (includes the InputStream/OutputStream compatibility layer)

### Changes
- `FileTransform.java`: `BufferedWriter`/`FileWriter` → `BufferedOutputStream`/`FileOutputStream`, `BufferedReader`/`InputStreamReader` → `BufferedInputStream`, `Writer` → `OutputStream` parameter
- `FileTransformTest.java`: `BufferedReader`/`InputStreamReader` → `BufferedInputStream`, `FileSerde.reader()` → `FileSerde.read()`, proper try-with-resources on input streams
- `gradle.properties`: `kestraVersion` 1.3.16 → 1.3.19

## Test plan
- [x] `./gradlew :plugin-script:compileJava :plugin-script:compileTestJava` passes
- [ ] CI tests pass
- [ ] QA validation before rolling out to other plugins

Refs: https://github.com/kestra-io/kestra/issues/3155