### PR TITLE
fix(ruby): await stdout log before asserting to prevent flaky test

### DIFF
--- a/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/ScriptTest.java
+++ b/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/ScriptTest.java
@@ -68,6 +68,8 @@ class ScriptTest {
         assertThat(run.getStdOutLineCount(), greaterThan(1));
         assertThat(run.getStdErrLineCount(), greaterThan(1));
 
+        TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("2010-06-04"));
+        TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("2011-06-04"));
         TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("2012-06-04"));
         receive.blockLast();
         assertThat(List.copyOf(logs).stream().filter(logEntry -> logEntry.getMessage() != null && logEntry.getMessage().contains("2010-06-04")).count(), is(1L));

--- a/plugin-script-ruby/src/test/java/io/kestra/plugin/scripts/ruby/ScriptTest.java
+++ b/plugin-script-ruby/src/test/java/io/kestra/plugin/scripts/ruby/ScriptTest.java
@@ -68,6 +68,7 @@ class ScriptTest {
         assertThat(run.getStdOutLineCount(), greaterThan(1));
         assertThat(run.getStdErrLineCount(), is(1));
 
+        TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("2012-12-25"));
         TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("2001-02-03"));
         receive.blockLast();
         assertThat(List.copyOf(logs).stream().filter(logEntry -> logEntry.getMessage() != null && logEntry.getMessage().contains("2012-12-25")).count(), is(1L));


### PR DESCRIPTION
## Summary

- `ScriptTest.script()` was flaky: awaited stderr log (`2001-02-03`) but the first count assertion checked stdout (`2012-12-25`)
- stdout and stderr are separate streams with no delivery-order guarantee in the log queue — stderr could arrive before stdout, leaving the `logs` list incomplete when the assertion ran
- Added `awaitLog` for the stdout message before the existing stderr await, so both are confirmed present before `blockLast()` and the count assertions

## Test plan

- [ ] Re-run `plugin-script-ruby:test` multiple times — `ScriptTest.script()` should pass consistently