### PR TITLE
test(scripts): raise ExecuteFlow timeout to fix cold-start flakes

### DIFF
--- a/plugin-script-bun/src/test/java/io/kestra/plugins/scripts/bun/RunnerTest.java
+++ b/plugin-script-bun/src/test/java/io/kestra/plugins/scripts/bun/RunnerTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 @KestraTest(startRunner = true)
 class RunnerTest {
     @Test
-    @ExecuteFlow("sanity-checks/all_bun.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_bun.yaml", timeout = "PT5M")
     void all_bun(Execution execution) {
         assertThat(execution.getTaskRunList(), hasSize(2));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/plugin-script-deno/src/test/java/io/kestra/plugins/scripts/deno/RunnerTest.java
+++ b/plugin-script-deno/src/test/java/io/kestra/plugins/scripts/deno/RunnerTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 @KestraTest(startRunner = true)
 class RunnerTest {
     @Test
-    @ExecuteFlow("sanity-checks/all_deno.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_deno.yaml", timeout = "PT5M")
     void all_deno(Execution execution) {
         assertThat(execution.getTaskRunList(), hasSize(2));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/plugin-script-dotnet/src/test/java/io/kestra/plugin/scripts/dotnet/RunnerTest.java
+++ b/plugin-script-dotnet/src/test/java/io/kestra/plugin/scripts/dotnet/RunnerTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 @KestraTest(startRunner = true)
 class RunnerTest {
     @Test
-    @ExecuteFlow("sanity-checks/all_dotnet.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_dotnet.yaml", timeout = "PT5M")
     void all_dotnet(Execution execution) {
         assertThat(execution.getTaskRunList(), hasSize(2));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/plugin-script-go/src/test/java/io/kestra/plugins/scripts/go/RunnerTest.java
+++ b/plugin-script-go/src/test/java/io/kestra/plugins/scripts/go/RunnerTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 @KestraTest(startRunner = true)
 class RunnerTest {
     @Test
-    @ExecuteFlow("sanity-checks/all_go.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_go.yaml", timeout = "PT5M")
     void all_go(Execution execution) {
         assertThat(execution.getTaskRunList(), hasSize(2));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));

--- a/plugin-script-php/src/test/java/io/kestra/plugin/scripts/php/RunnerTest.java
+++ b/plugin-script-php/src/test/java/io/kestra/plugin/scripts/php/RunnerTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 @KestraTest(startRunner = true)
 class RunnerTest {
     @Test
-    @ExecuteFlow("sanity-checks/all_php.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_php.yaml", timeout = "PT5M")
     void all_php(Execution execution) {
         assertThat(execution.getTaskRunList(), hasSize(2));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));


### PR DESCRIPTION
## What

Raise the `@ExecuteFlow` await timeout from the default 60s to `PT5M` on the heavier script runner tests: **go, dotnet, deno, bun, php**.

## Why

The `main` check failed on [run 28774084040](https://github.com/kestra-io/plugin-scripts/actions/runs/28774084040/job/85313971225):

```
> Task :plugin-script-go:test FAILED
org.junit.jupiter.api.extension.ParameterResolutionException:
  Execution 9AfwddQhvsAl8RiFCiQW6 is currently at the status RUNNING which is not the awaited one
```

`@ExecuteFlow`'s parameter resolver awaits the execution reaching a terminal state, with a default timeout of **60s** (`PT60S`). The `all_*.yaml` sanity-check flows run script tasks that compile/build inside a Docker task runner (Go's `all_go.yaml` runs two `go run` tasks that each compile). On a cold CI runner, image pull plus compilation exceeded 60s, so the execution was still `RUNNING` at the deadline — a cold-start flake, not a regression.

## Fix

```java
@ExecuteFlow(value = "sanity-checks/all_<lang>.yaml", timeout = "PT5M")
```

Applied to the runner tests most exposed to cold-start latency. Gives comfortable headroom for image pull + compilation while still failing fast on a genuine hang. All four modules compile (`compileTestJava`); go verified previously.

jbang, julia, and r don't use `@ExecuteFlow`, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)