### PR TITLE
fix(python): resolve real interpreter for Process runner without pythonVersion

### DIFF
--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManager.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManager.java
@@ -104,8 +104,16 @@ public class PythonEnvironmentManager {
         }
 
         String pythonInterpreter = "python";
-        if (pythonVersion != null && (taskRunner instanceof Process || RunnerType.PROCESS.equals(runnerType))) {
-            pythonInterpreter = resolver.getPythonPath(targetPythonVersion);
+        if (taskRunner instanceof Process || RunnerType.PROCESS.equals(runnerType)) {
+            // The Process runner executes commands directly on the worker host, which may only ship
+            // 'python3' (Debian/Ubuntu, the standard Kestra worker image) and not the bare 'python'
+            // literal. When an explicit pythonVersion is set, resolve it through the configured package
+            // manager (may provision a managed Python via 'uv'). Otherwise, probe for an interpreter
+            // that is already installed (python3, then python) rather than forcing a managed-Python
+            // download just to run a script with no dependencies.
+            pythonInterpreter = pythonVersion != null
+                ? resolver.getPythonPath(targetPythonVersion)
+                : PackageManagerType.PIP.getPythonPath(resolver, targetPythonVersion);
         }
 
         return new ResolvedPythonEnvironment(cached, resolvedPythonPackages, pythonInterpreter);

--- a/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManagerTest.java
+++ b/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManagerTest.java
@@ -1,0 +1,48 @@
+package io.kestra.plugin.scripts.python.internals;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.plugin.scripts.exec.scripts.models.RunnerType;
+import io.kestra.plugin.scripts.python.Script;
+
+import jakarta.inject.Inject;
+
+import static io.kestra.core.utils.TestsUtils.mockRunContext;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+@KestraTest
+class PythonEnvironmentManagerTest {
+
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Test
+    void shouldResolveARunnableInterpreterForProcessRunnerWithoutExplicitPythonVersion() throws Exception {
+        // Regression test: without an explicit pythonVersion, the Process runner used to default the
+        // interpreter to the literal "python", which doesn't exist on python3-only hosts (Debian/Ubuntu,
+        // the standard Kestra worker image), causing "/bin/sh: python: not found" (exit code 127).
+        Script task = Script.builder()
+            .id("python-env-manager-test-" + UUID.randomUUID())
+            .type(Script.class.getName())
+            .script(Property.ofValue("print('hello')"))
+            .build();
+        RunContext runContext = mockRunContext(runContextFactory, task, Map.of());
+
+        PythonEnvironmentManager manager = new PythonEnvironmentManager(runContext, task);
+        PythonEnvironmentManager.ResolvedPythonEnvironment environment = manager.setup(task.getContainerImage(), null, RunnerType.PROCESS);
+
+        assertThat(environment.interpreter(), is(not("python")));
+
+        Process process = new ProcessBuilder(environment.interpreter(), "--version").start();
+        assertThat(process.waitFor(), is(0));
+    }
+}

--- a/plugin-script-python/src/test/resources/sanity-checks/all_python.yaml
+++ b/plugin-script-python/src/test/resources/sanity-checks/all_python.yaml
@@ -44,7 +44,7 @@ tasks:
       main.py: |
         print("Hello, World from the Commands Task and Process Task Runner")
     commands:
-      - python main.py
+      - python3 main.py
 
   - id: python_script_logs
     type: io.kestra.plugin.scripts.python.Script


### PR DESCRIPTION
### What changes are being made and why?

Python `Script`/`Commands` tasks running on the **`Process` task runner** failed with `/bin/sh: python: not found` (exit code 127) on hosts that ship only `python3` (Debian/Ubuntu, and the standard Kestra worker image).

**Root cause:** In `PythonEnvironmentManager.setup()`, the interpreter was only resolved to an actual installed binary when `pythonVersion` was explicitly set. When it was unset (the common case) on a Process runner, the interpreter stayed the literal `"python"`, which doesn't exist on `python3`-only hosts. The Docker default runner was unaffected because `python:3.13-slim` symlinks `python`.

**Fix:** The Process runner now always resolves an installed interpreter. When `pythonVersion` is set, behavior is unchanged (resolved through the configured package manager, which may provision a managed Python via `uv`). When it's unset, we probe for an already-installed interpreter (`python3` → `python`) via `PackageManagerType.PIP.getPythonPath`, avoiding a managed-Python download just to run a dependency-free script. The Docker/Kubernetes path is untouched.

Also:
- Updated the `all_python` sanity-check flow: `python_commands_process` now uses `python3 main.py` (user-authored command, not routed through the resolver).
- Added `PythonEnvironmentManagerTest` regression test asserting a Process-runner Script with no `pythonVersion` resolves to a runnable, non-`"python"` interpreter.

---

### How the changes have been QAed?

- New `PythonEnvironmentManagerTest` passes.
- `ScriptTest.task[PROCESS]` — the exact case that reproduced the reported failure — now passes (previously exit 127).

```yaml
id: repro
namespace: sanitychecks.plugin-scripts
tasks:
  - id: python_script_process
    type: io.kestra.plugin.scripts.python.Script
    taskRunner:
      type: io.kestra.plugin.core.runner.Process
    script: |
      print("Hello from a Process Task Runner")
```
On a `python3`-only host this failed with `python: not found` before the fix and now succeeds.

---

### Contributor Checklist ✅

- [x] I have read and followed the [plugin contribution guidelines](https://kestra.io/docs/plugin-developer-guide/contribution-guidelines)
