### PR TITLE
fix(python): resolve interpreter through package manager when dependencies are installed

### DIFF
--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManager.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManager.java
@@ -107,11 +107,14 @@ public class PythonEnvironmentManager {
         if (taskRunner instanceof Process || RunnerType.PROCESS.equals(runnerType)) {
             // The Process runner executes commands directly on the worker host, which may only ship
             // 'python3' (Debian/Ubuntu, the standard Kestra worker image) and not the bare 'python'
-            // literal. When an explicit pythonVersion is set, resolve it through the configured package
-            // manager (may provision a managed Python via 'uv'). Otherwise, probe for an interpreter
-            // that is already installed (python3, then python) rather than forcing a managed-Python
-            // download just to run a script with no dependencies.
-            pythonInterpreter = pythonVersion != null
+            // literal. Key this on whether dependencies were actually installed, not just on whether
+            // pythonVersion was explicitly set: dependencies may have just been installed against a
+            // managed interpreter (e.g. uv-managed) that has no relation to whatever 'python'/'python3'
+            // is on the local PATH, so the script must run with that same interpreter. Only fall back to
+            // probing for an already-installed local interpreter when there is truly nothing else to go
+            // on (no explicit version and no dependencies), to avoid forcing a managed-Python download
+            // just to run a dependency-free script.
+            pythonInterpreter = (pythonVersion != null || !requirements.isEmpty())
                 ? resolver.getPythonPath(targetPythonVersion)
                 : PackageManagerType.PIP.getPythonPath(resolver, targetPythonVersion);
         }

--- a/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManagerTest.java
+++ b/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManagerTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.scripts.python.internals;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -18,6 +19,7 @@ import static io.kestra.core.utils.TestsUtils.mockRunContext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 @KestraTest
 class PythonEnvironmentManagerTest {
@@ -41,6 +43,37 @@ class PythonEnvironmentManagerTest {
         PythonEnvironmentManager.ResolvedPythonEnvironment environment = manager.setup(task.getContainerImage(), null, RunnerType.PROCESS);
 
         assertThat(environment.interpreter(), is(not("python")));
+
+        Process process = new ProcessBuilder(environment.interpreter(), "--version").start();
+        assertThat(process.waitFor(), is(0));
+    }
+
+    @Test
+    void shouldResolveTheManagedInterpreterForProcessRunnerWithDependenciesAndNoExplicitPythonVersion() throws Exception {
+        // Regression test for #397: with dependencies declared but no explicit pythonVersion, the
+        // interpreter used to be resolved via a hardcoded local PATH probe (PackageManagerType.PIP),
+        // regardless of the package manager that actually installed the dependencies. On a worker whose
+        // only Python is 'uv'-managed (no local python/python3 binary), that probe fails to find any
+        // interpreter at all, causing the script execution to fail ("python: not found", exit code 127).
+        // The interpreter must instead be resolved through the same package manager (UV here) that
+        // installed the dependencies, which returns the absolute path to the managed interpreter
+        // rather than a bare command name looked up on the local PATH.
+        Script task = Script.builder()
+            .id("python-env-manager-test-" + UUID.randomUUID())
+            .type(Script.class.getName())
+            .script(Property.ofValue("print('hello')"))
+            .packageManager(Property.ofValue(PackageManagerType.UV))
+            .dependencies(Property.ofValue(List.of("six")))
+            .build();
+        RunContext runContext = mockRunContext(runContextFactory, task, Map.of());
+
+        PythonEnvironmentManager manager = new PythonEnvironmentManager(runContext, task);
+        PythonEnvironmentManager.ResolvedPythonEnvironment environment = manager.setup(task.getContainerImage(), null, RunnerType.PROCESS);
+
+        assertThat(environment.interpreter(), is(not("python")));
+        // A bare PATH-looked-up command name (e.g. "python3") is relative; the UV-managed interpreter is
+        // always resolved to an absolute path, proving the resolution went through the package manager.
+        assertThat(environment.interpreter(), startsWith("/"));
 
         Process process = new ProcessBuilder(environment.interpreter(), "--version").start();
         assertThat(process.waitFor(), is(0));


### PR DESCRIPTION
## Summary

- `PythonEnvironmentManager.setup()` keyed interpreter resolution for the Process runner only on whether `pythonVersion` was explicitly set, so declaring `dependencies` without `pythonVersion` still fell back to a hardcoded local PATH probe (`PackageManagerType.PIP.getPythonPath`), even when the dependencies were just installed against a different (e.g. `uv`-managed) interpreter.
- On a worker whose only Python is `uv`-managed (no local `python`/`python3` binary), this caused the script execution to fail with `python: not found` (exit code 127) despite the dependencies having installed successfully.
- Fix: key the branch on whether dependencies were actually installed (`!requirements.isEmpty()`), not just on `pythonVersion` being set. When either is true, the interpreter is resolved through `resolver.getPythonPath(...)`, which dispatches through the package manager that actually installed the dependencies (idempotent for `uv`, unchanged behavior for `pip`). The local-PATH probe is now reserved for the case with no explicit version and no dependencies, preserving #394's intent.
- Added a regression test asserting that with `packageManager=UV`, dependencies declared, and no explicit `pythonVersion`, the resolved interpreter is an absolute uv-managed path (not the bare `python` literal, and not a relative PATH lookup like `python3`).

fixes: https://github.com/kestra-io/plugin-scripts/issues/397

## Test plan

- [x] `rtk test ./gradlew :plugin-script-python:test --tests "io.kestra.plugin.scripts.python.internals.*" --tests "io.kestra.plugin.scripts.python.CommandsTest"` passes
- [x] Existing regression test `shouldResolveARunnableInterpreterForProcessRunnerWithoutExplicitPythonVersion` (no dependencies) still passes unmodified, confirming the local-probe branch is preserved
- [x] New test `shouldResolveTheManagedInterpreterForProcessRunnerWithDependenciesAndNoExplicitPythonVersion` fails without the fix (routes through the local PATH probe) and passes with it

---
*[View as Artifact](https://claude.ai/code/artifact/e7c6e755-47b7-409b-bd6a-16215bf9a577)*