### PR TITLE
fix: register allure-results as a Test task output so it survives build-cache hits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,14 @@ subprojects {
 
     test {
         jvmArgs = [ "-javaagent:${configurations.agent.singleFile}" ]
+
+        // allure-junit5 writes results as a side effect of the test JVM, invisible to Gradle's
+        // dependency tracking. Without declaring it as a task output, a build-cache hit on :test
+        // (org.gradle.caching=true) restores build/test-results/ but skips the JVM entirely, so
+        // no allure-results are ever produced for that run.
+        def allureResultsDir = layout.buildDirectory.dir("allure-results")
+        systemProperty 'allure.results.directory', allureResultsDir.get().asFile.absolutePath
+        outputs.dir(allureResultsDir)
     }
 }
 


### PR DESCRIPTION
## Summary
- After kestra-io/actions#189 fixed the multi-module merge/history-restore step, the generated Allure report was still empty (`"total": 0`) on CI even though the JUnit XML report showed 240/240 tests passed.
- Root cause: `org.gradle.caching=true` is set here, and CI's `:test` tasks hit the Develocity remote build cache (`FROM-CACHE`) on unchanged runs. `allure-junit5` writes its result JSONs as a side effect of the test JVM — Gradle has no idea they exist since they aren't a declared task output — so a cache hit restores `build/test-results/*.xml` (a real output) but never runs the JVM, and no `allure-results` files are produced at all for that run.
- Fix: declare `build/allure-results` as an `outputs.dir(...)` of the `test` task (and pin `allure.results.directory` there via system property) so the build cache tracks and restores it together with the JUnit results.

## Test plan
- [x] `./gradlew :plugin-script-shell:test` — ran live, produced 111 files under `plugin-script-shell/build/allure-results/`.
- [x] Deleted the results dir, reran the same task — Gradle reported `:plugin-script-shell:test FROM-CACHE`, and all 111 files were restored from cache.
- [ ] Confirm the next scheduled `main` CI run populates a non-empty Allure report.