### PR TITLE
fix(python): honor an activated venv on the Process runner, with resolved-interpreter fallback

### DIFF
--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.SystemUtils;
+
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
@@ -15,8 +17,10 @@ import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.TargetOS;
+import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.runners.FilesService;
 import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.core.runner.Process;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
 import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
@@ -366,18 +370,15 @@ public class Script extends AbstractPythonExecScript implements RunnableTask<Scr
             env.put("PYTHONPATH", commands.getTaskRunner().toAbsolutePath(runContext, commands, relativePackagesPath.toString(), os));
         }
 
+        String scriptPath = commands.getTaskRunner().toAbsolutePath(runContext, commands, relativeScriptPath.toString(), os);
+        String runCommand = buildRunCommand(os, commands.getTaskRunner(), pythonEnvironment, scriptPath);
+
         ScriptOutput output = commands
             .addEnv(env)
             .withInterpreter(this.interpreter)
             .withBeforeCommands(beforeCommands)
             .withBeforeCommandsWithOptions(true)
-            .withCommands(
-                Property.ofValue(
-                    List.of(
-                        String.join(" ", pythonEnvironment.interpreter(), commands.getTaskRunner().toAbsolutePath(runContext, commands, relativeScriptPath.toString(), os))
-                    )
-                )
-            )
+            .withCommands(Property.ofValue(List.of(runCommand)))
             .withTargetOS(os)
             .run();
 
@@ -386,5 +387,37 @@ public class Script extends AbstractPythonExecScript implements RunnableTask<Scr
             pythonEnvironmentManager.uploadCache(runContext, pythonEnvironment.packages());
         }
         return output;
+    }
+
+    /**
+     * Builds the shell command that invokes the script.
+     * <p>
+     * When the plugin installed dependencies itself ({@code packages() != null}), PYTHONPATH already
+     * points to them and the resolved interpreter is authoritative: kept as the historical single-token
+     * invocation, unchanged.
+     * <p>
+     * Otherwise, a venv activated via {@code beforeCommands} (e.g. {@code . .venv/bin/activate}) only
+     * mutates the shell's PATH/VIRTUAL_ENV — it never changes which interpreter Kestra invokes. Since
+     * beforeCommands and this command run in the same shell, prefer that activated venv's python at
+     * runtime, falling back to the resolved interpreter (managed or bare) when no venv is active.
+     * <p>
+     * Package-private so the branching can be asserted directly without executing a process.
+     */
+    static String buildRunCommand(TargetOS os, TaskRunner<?> taskRunner, ResolvedPythonEnvironment pythonEnvironment, String scriptPath) {
+        String resolvedInterpreter = pythonEnvironment.interpreter();
+
+        if (pythonEnvironment.packages() != null) {
+            return String.join(" ", resolvedInterpreter, scriptPath);
+        }
+
+        return isWindowsTarget(os, taskRunner)
+            ? "if ($env:VIRTUAL_ENV) { & \"$env:VIRTUAL_ENV\\Scripts\\python.exe\" \"" + scriptPath + "\" } else { & \"" + resolvedInterpreter + "\" \"" + scriptPath + "\" }"
+            : "if [ -n \"$VIRTUAL_ENV\" ]; then \"$VIRTUAL_ENV/bin/python\" \"" + scriptPath + "\"; else \"" + resolvedInterpreter + "\" \"" + scriptPath + "\"; fi";
+    }
+
+    // Mirrors CommandsWrapper#getExitOnErrorCommands: targetOS is authoritative, AUTO only resolves to
+    // Windows when the worker itself runs Windows and the script executes directly on it (Process runner).
+    private static boolean isWindowsTarget(TargetOS os, TaskRunner<?> taskRunner) {
+        return os == TargetOS.WINDOWS || (os == TargetOS.AUTO && SystemUtils.IS_OS_WINDOWS && taskRunner instanceof Process);
     }
 }

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
@@ -5,8 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.SystemUtils;
-
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
@@ -17,10 +15,8 @@ import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.TargetOS;
-import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.runners.FilesService;
 import io.kestra.core.runners.RunContext;
-import io.kestra.plugin.core.runner.Process;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
 import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
@@ -371,7 +367,7 @@ public class Script extends AbstractPythonExecScript implements RunnableTask<Scr
         }
 
         String scriptPath = commands.getTaskRunner().toAbsolutePath(runContext, commands, relativeScriptPath.toString(), os);
-        String runCommand = buildRunCommand(os, commands.getTaskRunner(), pythonEnvironment, scriptPath);
+        String runCommand = buildRunCommand(pythonEnvironment, scriptPath);
 
         ScriptOutput output = commands
             .addEnv(env)
@@ -392,32 +388,19 @@ public class Script extends AbstractPythonExecScript implements RunnableTask<Scr
     /**
      * Builds the shell command that invokes the script.
      * <p>
-     * When the plugin installed dependencies itself ({@code packages() != null}), PYTHONPATH already
-     * points to them and the resolved interpreter is authoritative: kept as the historical single-token
-     * invocation, unchanged.
+     * When the plugin installed dependencies itself ({@code packages() != null}), those packages were
+     * installed against the resolved interpreter, which is authoritative: kept as the historical
+     * single-token invocation, unchanged.
      * <p>
-     * Otherwise, a venv activated via {@code beforeCommands} (e.g. {@code . .venv/bin/activate}) only
-     * mutates the shell's PATH/VIRTUAL_ENV — it never changes which interpreter Kestra invokes. Since
-     * beforeCommands and this command run in the same shell, prefer that activated venv's python at
-     * runtime, falling back to the resolved interpreter (managed or bare) when no venv is active.
+     * Otherwise, the user manages their own environment (e.g. a venv activated in {@code beforeCommands}),
+     * so run bare {@code python} exactly like the Commands task, which resolves through the shell's PATH
+     * and therefore honors that activated venv.
      * <p>
      * Package-private so the branching can be asserted directly without executing a process.
      */
-    static String buildRunCommand(TargetOS os, TaskRunner<?> taskRunner, ResolvedPythonEnvironment pythonEnvironment, String scriptPath) {
-        String resolvedInterpreter = pythonEnvironment.interpreter();
-
-        if (pythonEnvironment.packages() != null) {
-            return String.join(" ", resolvedInterpreter, scriptPath);
-        }
-
-        return isWindowsTarget(os, taskRunner)
-            ? "if ($env:VIRTUAL_ENV) { & \"$env:VIRTUAL_ENV\\Scripts\\python.exe\" \"" + scriptPath + "\" } else { & \"" + resolvedInterpreter + "\" \"" + scriptPath + "\" }"
-            : "if [ -n \"$VIRTUAL_ENV\" ]; then \"$VIRTUAL_ENV/bin/python\" \"" + scriptPath + "\"; else \"" + resolvedInterpreter + "\" \"" + scriptPath + "\"; fi";
-    }
-
-    // Mirrors CommandsWrapper#getExitOnErrorCommands: targetOS is authoritative, AUTO only resolves to
-    // Windows when the worker itself runs Windows and the script executes directly on it (Process runner).
-    private static boolean isWindowsTarget(TargetOS os, TaskRunner<?> taskRunner) {
-        return os == TargetOS.WINDOWS || (os == TargetOS.AUTO && SystemUtils.IS_OS_WINDOWS && taskRunner instanceof Process);
+    static String buildRunCommand(ResolvedPythonEnvironment pythonEnvironment, String scriptPath) {
+        return pythonEnvironment.packages() != null
+            ? String.join(" ", pythonEnvironment.interpreter(), scriptPath)
+            : String.join(" ", "python", scriptPath);
     }
 }

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/Script.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.SystemUtils;
+
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
@@ -15,8 +17,10 @@ import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.TargetOS;
+import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.runners.FilesService;
 import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.core.runner.Process;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
 import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
@@ -38,7 +42,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @Schema(
     title = "Run inline Python script",
-    description = "Executes a multi-line Python script inside the default 'python:3.13-slim' image unless overridden. Handles dependency install via UV (default) or pip with optional cache; script is saved to a temp .py file and run with the resolved interpreter. Use Commands task to run existing files."
+    description = "Executes a multi-line Python script inside the default 'python:3.13-slim' image unless overridden. Handles dependency install via UV (default) or pip with optional cache; script is saved to a temp .py file and run with the resolved interpreter, or an activated virtualenv when one is set up in beforeCommands. Use Commands task to run existing files."
 )
 @Plugin(
     examples = {
@@ -311,7 +315,7 @@ public class Script extends AbstractPythonExecScript implements RunnableTask<Scr
 
     @Schema(
         title = "Inline Python script",
-        description = "Python source as a multi-line string; written to a temporary .py file and executed with the resolved interpreter. For existing files, use the Commands task."
+        description = "Python source as a multi-line string; written to a temporary .py file and executed with the resolved interpreter, or an activated virtualenv when one is set up in beforeCommands. For existing files, use the Commands task."
     )
     @NotNull
     @PluginProperty(language = MonacoLanguages.PYTHON, group = "main")
@@ -366,8 +370,8 @@ public class Script extends AbstractPythonExecScript implements RunnableTask<Scr
             env.put("PYTHONPATH", commands.getTaskRunner().toAbsolutePath(runContext, commands, relativePackagesPath.toString(), os));
         }
 
-        String scriptPath = commands.getTaskRunner().toAbsolutePath(runContext, commands, relativeScriptPath.toString(), os);
-        String runCommand = buildRunCommand(pythonEnvironment, scriptPath);
+        var scriptPath = commands.getTaskRunner().toAbsolutePath(runContext, commands, relativeScriptPath.toString(), os);
+        var runCommand = buildRunCommand(os, commands.getTaskRunner(), pythonEnvironment, scriptPath);
 
         ScriptOutput output = commands
             .addEnv(env)
@@ -389,18 +393,30 @@ public class Script extends AbstractPythonExecScript implements RunnableTask<Scr
      * Builds the shell command that invokes the script.
      * <p>
      * When the plugin installed dependencies itself ({@code packages() != null}), those packages were
-     * installed against the resolved interpreter, which is authoritative: kept as the historical
-     * single-token invocation, unchanged.
+     * installed against the resolved interpreter, which is authoritative. Windows also keeps this form,
+     * since there is no reliable PowerShell equivalent of the POSIX venv-detection below.
      * <p>
-     * Otherwise, the user manages their own environment (e.g. a venv activated in {@code beforeCommands}),
-     * so run bare {@code python} exactly like the Commands task, which resolves through the shell's PATH
-     * and therefore honors that activated venv.
+     * Otherwise, on POSIX, the user manages their own environment (e.g. a venv activated in
+     * {@code beforeCommands}, where {@code . .venv/bin/activate} only mutates PATH/VIRTUAL_ENV in the
+     * shared shell). Prefer that activated venv's python; fall back to the resolved interpreter, which
+     * already probes python3/python and honors a pinned or managed pythonVersion, so python3-only
+     * workers still work when no venv is active.
      * <p>
      * Package-private so the branching can be asserted directly without executing a process.
      */
-    static String buildRunCommand(ResolvedPythonEnvironment pythonEnvironment, String scriptPath) {
-        return pythonEnvironment.packages() != null
-            ? String.join(" ", pythonEnvironment.interpreter(), scriptPath)
-            : String.join(" ", "python", scriptPath);
+    static String buildRunCommand(TargetOS os, TaskRunner<?> taskRunner, ResolvedPythonEnvironment pythonEnvironment, String scriptPath) {
+        String resolvedInterpreter = pythonEnvironment.interpreter();
+
+        if (pythonEnvironment.packages() != null || isWindowsTarget(os, taskRunner)) {
+            return String.join(" ", resolvedInterpreter, scriptPath);
+        }
+
+        return "if [ -n \"$VIRTUAL_ENV\" ]; then \"$VIRTUAL_ENV/bin/python\" \"" + scriptPath + "\"; else \"" + resolvedInterpreter + "\" \"" + scriptPath + "\"; fi";
+    }
+
+    // Mirrors CommandsWrapper#getExitOnErrorCommands: targetOS is authoritative, AUTO only resolves to
+    // Windows when the worker itself runs Windows and the script executes directly on it (Process runner).
+    private static boolean isWindowsTarget(TargetOS os, TaskRunner<?> taskRunner) {
+        return os == TargetOS.WINDOWS || (os == TargetOS.AUTO && SystemUtils.IS_OS_WINDOWS && taskRunner instanceof Process);
     }
 }

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManager.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManager.java
@@ -107,16 +107,14 @@ public class PythonEnvironmentManager {
         if (taskRunner instanceof Process || RunnerType.PROCESS.equals(runnerType)) {
             // The Process runner executes commands directly on the worker host, which may only ship
             // 'python3' (Debian/Ubuntu, the standard Kestra worker image) and not the bare 'python'
-            // literal. Key this on whether dependencies were actually installed, not on whether
-            // pythonVersion was explicitly set: dependencies were just installed against a managed
-            // interpreter (e.g. uv-managed) that has no relation to whatever 'python'/'python3' is on
-            // the local PATH, so the script must run with that same interpreter. Otherwise (no
-            // dependencies), the user manages their own environment — e.g. a venv activated in
-            // beforeCommands — so probe the local interpreter via PATH instead of forcing the resolved
-            // interpreter: forcing it would both ignore that activated venv and force a managed-Python
-            // download (e.g. via uv) just to run a dependency-free script, which fails outright on a
-            // network-restricted worker.
-            pythonInterpreter = !requirements.isEmpty()
+            // literal. Key this on whether dependencies were actually installed, not just on whether
+            // pythonVersion was explicitly set: dependencies may have just been installed against a
+            // managed interpreter (e.g. uv-managed) that has no relation to whatever 'python'/'python3'
+            // is on the local PATH, so the script must run with that same interpreter. Only fall back to
+            // probing for an already-installed local interpreter when there is truly nothing else to go
+            // on (no explicit version and no dependencies), to avoid forcing a managed-Python download
+            // just to run a dependency-free script.
+            pythonInterpreter = (pythonVersion != null || !requirements.isEmpty())
                 ? resolver.getPythonPath(targetPythonVersion)
                 : PackageManagerType.PIP.getPythonPath(resolver, targetPythonVersion);
         }

--- a/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManager.java
+++ b/plugin-script-python/src/main/java/io/kestra/plugin/scripts/python/internals/PythonEnvironmentManager.java
@@ -107,14 +107,16 @@ public class PythonEnvironmentManager {
         if (taskRunner instanceof Process || RunnerType.PROCESS.equals(runnerType)) {
             // The Process runner executes commands directly on the worker host, which may only ship
             // 'python3' (Debian/Ubuntu, the standard Kestra worker image) and not the bare 'python'
-            // literal. Key this on whether dependencies were actually installed, not just on whether
-            // pythonVersion was explicitly set: dependencies may have just been installed against a
-            // managed interpreter (e.g. uv-managed) that has no relation to whatever 'python'/'python3'
-            // is on the local PATH, so the script must run with that same interpreter. Only fall back to
-            // probing for an already-installed local interpreter when there is truly nothing else to go
-            // on (no explicit version and no dependencies), to avoid forcing a managed-Python download
-            // just to run a dependency-free script.
-            pythonInterpreter = (pythonVersion != null || !requirements.isEmpty())
+            // literal. Key this on whether dependencies were actually installed, not on whether
+            // pythonVersion was explicitly set: dependencies were just installed against a managed
+            // interpreter (e.g. uv-managed) that has no relation to whatever 'python'/'python3' is on
+            // the local PATH, so the script must run with that same interpreter. Otherwise (no
+            // dependencies), the user manages their own environment — e.g. a venv activated in
+            // beforeCommands — so probe the local interpreter via PATH instead of forcing the resolved
+            // interpreter: forcing it would both ignore that activated venv and force a managed-Python
+            // download (e.g. via uv) just to run a dependency-free script, which fails outright on a
+            // network-restricted worker.
+            pythonInterpreter = !requirements.isEmpty()
                 ? resolver.getPythonPath(targetPythonVersion)
                 : PackageManagerType.PIP.getPythonPath(resolver, targetPythonVersion);
         }

--- a/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/ScriptTest.java
+++ b/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/ScriptTest.java
@@ -20,13 +20,11 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.AbstractMetricEntry;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTaskException;
-import io.kestra.core.models.tasks.runners.TargetOS;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.TestsUtils;
-import io.kestra.plugin.core.runner.Process;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.RunnerType;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
@@ -351,7 +349,8 @@ class ScriptTest {
         // resolves an absolute managed interpreter (e.g. uv-installed). Before the fix, that absolute
         // path was invoked directly, ignoring a venv activated in beforeCommands (`. .venv/bin/activate`
         // only mutates PATH/VIRTUAL_ENV in the shell), so imports of venv-installed packages failed with
-        // ModuleNotFoundError. The fix prefers the activated venv's python at shell runtime.
+        // ModuleNotFoundError. Since no dependencies are installed here, the script now runs via bare
+        // `python` (like the Commands task), which resolves through the activated venv's PATH.
         Script python = Script.builder()
             .id("python-script-venv-" + UUID.randomUUID())
             .type(Script.class.getName())
@@ -382,15 +381,11 @@ class ScriptTest {
     }
 
     @Test
-    void buildRunCommandPrefersActivatedVenvWhenNoManagedPackages() {
+    void buildRunCommandUsesBarePythonWhenNoManagedPackages() {
         ResolvedPythonEnvironment noPackages = new ResolvedPythonEnvironment(false, null, "/root/.local/share/uv/python/cpython-3.13/bin/python3");
 
-        String posixCommand = Script.buildRunCommand(TargetOS.LINUX, new Process(), noPackages, "/working/dir/script.py");
-        assertThat(posixCommand, containsString("$VIRTUAL_ENV"));
-        assertThat(posixCommand, containsString("/root/.local/share/uv/python/cpython-3.13/bin/python3"));
-
-        String windowsCommand = Script.buildRunCommand(TargetOS.WINDOWS, new Process(), noPackages, "C:\\working\\dir\\script.py");
-        assertThat(windowsCommand, containsString("$env:VIRTUAL_ENV"));
+        String command = Script.buildRunCommand(noPackages, "/working/dir/script.py");
+        assertThat(command, is("python /working/dir/script.py"));
     }
 
     @Test
@@ -398,9 +393,8 @@ class ScriptTest {
         ResolvedPythonPackages packages = new ResolvedPythonPackages(Path.of("/tmp/packages"), Path.of("/tmp/requirements.txt"), "hash", "3.13");
         ResolvedPythonEnvironment withPackages = new ResolvedPythonEnvironment(false, packages, "/managed/python3");
 
-        String command = Script.buildRunCommand(TargetOS.LINUX, new Process(), withPackages, "/working/dir/script.py");
+        String command = Script.buildRunCommand(withPackages, "/working/dir/script.py");
         assertThat(command, is("/managed/python3 /working/dir/script.py"));
-        assertThat(command, not(containsString("VIRTUAL_ENV")));
     }
 
     @SuppressWarnings("unchecked")

--- a/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/ScriptTest.java
+++ b/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/ScriptTest.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -337,6 +338,46 @@ class ScriptTest {
         assertThat(run.getVars().get("t"), is(true));
         assertThat(run.getVars().get("f"), is(false));
         assertThat(run.getVars().get("n"), nullValue());
+    }
+
+    @Test
+    void shouldUseActivatedVenvOverManagedInterpreterOnProcessRunner() throws Exception {
+        // Regression for #404: on the Process runner, setting pythonVersion without `dependencies`
+        // used to force resolution of a managed (e.g. uv-installed) interpreter, ignoring any venv
+        // activated in beforeCommands (`. .venv/bin/activate` only mutates PATH/VIRTUAL_ENV) and, on a
+        // network-restricted worker, timing out entirely trying to download that managed interpreter.
+        // Since no dependencies are installed here, the interpreter must now be probed via PATH so the
+        // activated venv's python (with the venv-installed package) is what actually runs the script.
+        Script python = Script.builder()
+            .id("python-script-venv-" + UUID.randomUUID())
+            .type(Script.class.getName())
+            .runner(RunnerType.PROCESS)
+            .pythonVersion(Property.ofValue("3.13"))
+            .beforeCommands(
+                Property.ofValue(
+                    List.of(
+                        // Mirrors PackageManagerType.PIP#getPythonPath's own candidate order
+                        // ("python3.13" then "python3") so the venv is created with whichever
+                        // interpreter binary name will also be resolved and invoked at runtime.
+                        "python3.13 -m venv .venv 2>/dev/null || python3 -m venv .venv",
+                        ". .venv/bin/activate",
+                        "pip install six > /dev/null"
+                    )
+                )
+            )
+            .script(
+                Property.ofValue(
+                    "import six\n" +
+                        "print('::{\"outputs\": {\"extract\":\"' + six.__name__ + '\"}}::')"
+                )
+            )
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, python, ImmutableMap.of());
+        ScriptOutput run = python.run(runContext);
+
+        assertThat(run.getExitCode(), is(0));
+        assertThat(run.getVars().get("extract"), is("six"));
     }
 
     @SuppressWarnings("unchecked")

--- a/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/ScriptTest.java
+++ b/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/ScriptTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.scripts.python;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -19,14 +20,18 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.AbstractMetricEntry;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTaskException;
+import io.kestra.core.models.tasks.runners.TargetOS;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.core.runner.Process;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.RunnerType;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.kestra.plugin.scripts.python.internals.PythonEnvironmentManager.ResolvedPythonEnvironment;
+import io.kestra.plugin.scripts.python.internals.ResolvedPythonPackages;
 
 import jakarta.inject.Inject;
 import jakarta.validation.ConstraintViolationException;
@@ -343,11 +348,10 @@ class ScriptTest {
     @Test
     void shouldUseActivatedVenvOverManagedInterpreterOnProcessRunner() throws Exception {
         // Regression for #404: on the Process runner, setting pythonVersion without `dependencies`
-        // used to force resolution of a managed (e.g. uv-installed) interpreter, ignoring any venv
-        // activated in beforeCommands (`. .venv/bin/activate` only mutates PATH/VIRTUAL_ENV) and, on a
-        // network-restricted worker, timing out entirely trying to download that managed interpreter.
-        // Since no dependencies are installed here, the interpreter must now be probed via PATH so the
-        // activated venv's python (with the venv-installed package) is what actually runs the script.
+        // resolves an absolute managed interpreter (e.g. uv-installed). Before the fix, that absolute
+        // path was invoked directly, ignoring a venv activated in beforeCommands (`. .venv/bin/activate`
+        // only mutates PATH/VIRTUAL_ENV in the shell), so imports of venv-installed packages failed with
+        // ModuleNotFoundError. The fix prefers the activated venv's python at shell runtime.
         Script python = Script.builder()
             .id("python-script-venv-" + UUID.randomUUID())
             .type(Script.class.getName())
@@ -356,10 +360,7 @@ class ScriptTest {
             .beforeCommands(
                 Property.ofValue(
                     List.of(
-                        // Mirrors PackageManagerType.PIP#getPythonPath's own candidate order
-                        // ("python3.13" then "python3") so the venv is created with whichever
-                        // interpreter binary name will also be resolved and invoked at runtime.
-                        "python3.13 -m venv .venv 2>/dev/null || python3 -m venv .venv",
+                        "python3 -m venv .venv",
                         ". .venv/bin/activate",
                         "pip install six > /dev/null"
                     )
@@ -378,6 +379,28 @@ class ScriptTest {
 
         assertThat(run.getExitCode(), is(0));
         assertThat(run.getVars().get("extract"), is("six"));
+    }
+
+    @Test
+    void buildRunCommandPrefersActivatedVenvWhenNoManagedPackages() {
+        ResolvedPythonEnvironment noPackages = new ResolvedPythonEnvironment(false, null, "/root/.local/share/uv/python/cpython-3.13/bin/python3");
+
+        String posixCommand = Script.buildRunCommand(TargetOS.LINUX, new Process(), noPackages, "/working/dir/script.py");
+        assertThat(posixCommand, containsString("$VIRTUAL_ENV"));
+        assertThat(posixCommand, containsString("/root/.local/share/uv/python/cpython-3.13/bin/python3"));
+
+        String windowsCommand = Script.buildRunCommand(TargetOS.WINDOWS, new Process(), noPackages, "C:\\working\\dir\\script.py");
+        assertThat(windowsCommand, containsString("$env:VIRTUAL_ENV"));
+    }
+
+    @Test
+    void buildRunCommandKeepsSingleTokenInvocationWhenPackagesManaged() {
+        ResolvedPythonPackages packages = new ResolvedPythonPackages(Path.of("/tmp/packages"), Path.of("/tmp/requirements.txt"), "hash", "3.13");
+        ResolvedPythonEnvironment withPackages = new ResolvedPythonEnvironment(false, packages, "/managed/python3");
+
+        String command = Script.buildRunCommand(TargetOS.LINUX, new Process(), withPackages, "/working/dir/script.py");
+        assertThat(command, is("/managed/python3 /working/dir/script.py"));
+        assertThat(command, not(containsString("VIRTUAL_ENV")));
     }
 
     @SuppressWarnings("unchecked")

--- a/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/ScriptTest.java
+++ b/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/ScriptTest.java
@@ -20,11 +20,13 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.AbstractMetricEntry;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTaskException;
+import io.kestra.core.models.tasks.runners.TargetOS;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.core.runner.Process;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.RunnerType;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
@@ -349,8 +351,7 @@ class ScriptTest {
         // resolves an absolute managed interpreter (e.g. uv-installed). Before the fix, that absolute
         // path was invoked directly, ignoring a venv activated in beforeCommands (`. .venv/bin/activate`
         // only mutates PATH/VIRTUAL_ENV in the shell), so imports of venv-installed packages failed with
-        // ModuleNotFoundError. Since no dependencies are installed here, the script now runs via bare
-        // `python` (like the Commands task), which resolves through the activated venv's PATH.
+        // ModuleNotFoundError. The fix prefers the activated venv's python at shell runtime.
         Script python = Script.builder()
             .id("python-script-venv-" + UUID.randomUUID())
             .type(Script.class.getName())
@@ -381,11 +382,30 @@ class ScriptTest {
     }
 
     @Test
-    void buildRunCommandUsesBarePythonWhenNoManagedPackages() {
-        ResolvedPythonEnvironment noPackages = new ResolvedPythonEnvironment(false, null, "/root/.local/share/uv/python/cpython-3.13/bin/python3");
+    void buildRunCommandPrefersActivatedVenvButFallsBackToResolvedInterpreterOnPosix() {
+        String resolvedInterpreter = "/root/.local/share/uv/python/cpython-3.13/bin/python3.13";
+        ResolvedPythonEnvironment noPackages = new ResolvedPythonEnvironment(false, null, resolvedInterpreter);
 
-        String command = Script.buildRunCommand(noPackages, "/working/dir/script.py");
-        assertThat(command, is("python /working/dir/script.py"));
+        String command = Script.buildRunCommand(TargetOS.LINUX, new Process(), noPackages, "/working/dir/script.py");
+
+        assertThat(command, containsString("if [ -n \"$VIRTUAL_ENV\" ]"));
+        assertThat(command, containsString("$VIRTUAL_ENV/bin/python"));
+        // The missing-package fallback branch must invoke the resolved interpreter, not a bare
+        // 'python': the standard Kestra worker only ships 'python3', and a pinned/managed pythonVersion
+        // must still be honored when no venv is active.
+        assertThat(command, containsString(resolvedInterpreter));
+        assertThat(command, not(containsString(" python ")));
+    }
+
+    @Test
+    void buildRunCommandKeepsSingleTokenInvocationOnWindowsEvenWithoutManagedPackages() {
+        String resolvedInterpreter = "/root/.local/share/uv/python/cpython-3.13/bin/python3.13";
+        ResolvedPythonEnvironment noPackages = new ResolvedPythonEnvironment(false, null, resolvedInterpreter);
+
+        String command = Script.buildRunCommand(TargetOS.WINDOWS, new Process(), noPackages, "C:\\working\\dir\\script.py");
+
+        assertThat(command, is(resolvedInterpreter + " C:\\working\\dir\\script.py"));
+        assertThat(command, not(containsString("VIRTUAL_ENV")));
     }
 
     @Test
@@ -393,8 +413,10 @@ class ScriptTest {
         ResolvedPythonPackages packages = new ResolvedPythonPackages(Path.of("/tmp/packages"), Path.of("/tmp/requirements.txt"), "hash", "3.13");
         ResolvedPythonEnvironment withPackages = new ResolvedPythonEnvironment(false, packages, "/managed/python3");
 
-        String command = Script.buildRunCommand(withPackages, "/working/dir/script.py");
+        String command = Script.buildRunCommand(TargetOS.LINUX, new Process(), withPackages, "/working/dir/script.py");
+
         assertThat(command, is("/managed/python3 /working/dir/script.py"));
+        assertThat(command, not(containsString("VIRTUAL_ENV")));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## What

On the Process task runner, `io.kestra.plugin.scripts.python.Script` launched the script with the plugin's resolved interpreter by **absolute path**. When a venv was activated in `beforeCommands` (`. .venv/bin/activate`, which only mutates `PATH`/`VIRTUAL_ENV`), that absolute path bypassed the venv, so imports of venv-installed packages failed with `ModuleNotFoundError`. `Commands` was unaffected because it forwards user commands verbatim, so a bare `python` resolves through the activated `PATH`.

## Fix

`beforeCommands` and the run command execute in one shared shell, so the venv choice can be made at runtime. On the Process runner with no `dependencies`, prefer an activated venv, and fall back to the resolved interpreter otherwise:

```java
static String buildRunCommand(TargetOS os, TaskRunner<?> taskRunner, ResolvedPythonEnvironment pythonEnvironment, String scriptPath) {
    String resolvedInterpreter = pythonEnvironment.interpreter();

    // deps installed (packages resolved against this interpreter) or Windows -> unchanged
    if (pythonEnvironment.packages() != null || isWindowsTarget(os, taskRunner)) {
        return String.join(" ", resolvedInterpreter, scriptPath);
    }

    // no deps on POSIX -> use the venv if active, else the resolved interpreter
    return "if [ -n \"$VIRTUAL_ENV\" ]; then \"$VIRTUAL_ENV/bin/python\" \"" + scriptPath + "\"; else \"" + resolvedInterpreter + "\" \"" + scriptPath + "\"; fi";
}
```

The fallback is the **resolved** interpreter, which already probes `python3`/`python` and honors a pinned or managed `pythonVersion`. That keeps python3-only workers and pinned versions working when no venv is active. `PythonEnvironmentManager` interpreter resolution is unchanged.

## Behavior

| Case | Result |
|---|---|
| venv activated, no deps (the reported bug) | venv's python runs -> imports resolve |
| no venv, no deps, python3-only worker | resolved interpreter (`python3`) -> works |
| no venv, no deps, `pythonVersion` set | resolved managed interpreter -> pinned version honored |
| `dependencies` set | resolved interpreter + `PYTHONPATH`, unchanged |
| Windows | resolved interpreter, unchanged (no PowerShell branch) |

## Testing

- `ScriptTest.shouldUseActivatedVenvOverManagedInterpreterOnProcessRunner`: Process runner, `pythonVersion` set, no `dependencies`, a venv built and activated in `beforeCommands` installing a package, imported by the script. Asserts success.
- `buildRunCommand` unit tests: POSIX no-deps produces the `VIRTUAL_ENV` conditional with the **resolved interpreter** in the fallback branch; Windows and packages-present cases produce the single-token resolved-interpreter form.
- Full `:plugin-script-python:test`: all pass except a pre-existing `shouldExecScriptGivenDependency[DOCKER]` numpy/pandas cross-platform failure that also fails on `main` and runs on the unchanged `dependencies` path.

Fixes #404