### PR TITLE
fix(groovy): default the Docker runner to root for Commands tasks

### DIFF
--- a/plugin-script-groovy/build.gradle
+++ b/plugin-script-groovy/build.gradle
@@ -18,4 +18,5 @@ dependencies {
     api group: 'org.apache.groovy', name: 'groovy-jsr223', version: '5.1.1'
 
     testImplementation project(path: ':plugin-script', configuration: 'testOutput')
+    testImplementation group: 'com.github.docker-java', name: 'docker-java-api', version: '3.6.0'
 }

--- a/plugin-script-groovy/src/main/java/io/kestra/plugin/scripts/groovy/Commands.java
+++ b/plugin-script-groovy/src/main/java/io/kestra/plugin/scripts/groovy/Commands.java
@@ -9,10 +9,13 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.TargetOS;
+import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.scripts.exec.AbstractExecScript;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
+import io.kestra.plugin.scripts.runner.docker.Docker;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -94,6 +97,10 @@ public class Commands extends AbstractExecScript implements RunnableTask<ScriptO
         if (original.getImage() == null) {
             builder.image(runContext.render(this.getContainerImage()).as(String.class).orElse(null));
         }
+        // mirrors the taskRunner-based default below, for the deprecated `docker` property path.
+        if (original.getUser() == null) {
+            builder.user("root");
+        }
         return builder.build();
     }
 
@@ -101,12 +108,19 @@ public class Commands extends AbstractExecScript implements RunnableTask<ScriptO
     public ScriptOutput run(RunContext runContext) throws Exception {
         TargetOS os = runContext.render(this.targetOS).as(TargetOS.class).orElse(null);
 
-        return this.commands(runContext)
+        CommandsWrapper commandsWrapper = this.commands(runContext)
             .withInterpreter(this.interpreter)
             .withBeforeCommands(beforeCommands)
             .withBeforeCommandsWithOptions(true)
             .withCommands(commands)
-            .withTargetOS(os)
-            .run();
+            .withTargetOS(os);
+
+        // Docker can create the working directory owned by a user other than the non-root image user (e.g. `groovy` on `groovy:jdk21`), breaking outputFiles - see #411.
+        TaskRunner<?> taskRunner = commandsWrapper.getTaskRunner();
+        if (taskRunner instanceof Docker docker && docker.getUser() == null) {
+            commandsWrapper = commandsWrapper.withTaskRunner(docker.toBuilder().user("root").build());
+        }
+
+        return commandsWrapper.run();
     }
 }

--- a/plugin-script-groovy/src/main/java/io/kestra/plugin/scripts/groovy/Commands.java
+++ b/plugin-script-groovy/src/main/java/io/kestra/plugin/scripts/groovy/Commands.java
@@ -29,7 +29,10 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @Schema(
     title = "Execute Groovy files and commands",
-    description = "Runs Groovy commands or files in the JVM and captures their output."
+    description = """
+        Runs Groovy commands or files in the JVM and captures their output.
+
+        On the Docker task runner, the container runs as `root` unless `taskRunner.user` is set explicitly, so the task can always write into its working directory (which `outputFiles` requires). Set `taskRunner.user` to keep the image's own default user instead."""
 )
 @Plugin(
     examples = {
@@ -97,7 +100,7 @@ public class Commands extends AbstractExecScript implements RunnableTask<ScriptO
         if (original.getImage() == null) {
             builder.image(runContext.render(this.getContainerImage()).as(String.class).orElse(null));
         }
-        // mirrors the taskRunner-based default below, for the deprecated `docker` property path.
+        // Same root default as run(), for the deprecated `docker` property path - see #411.
         if (original.getUser() == null) {
             builder.user("root");
         }
@@ -115,7 +118,7 @@ public class Commands extends AbstractExecScript implements RunnableTask<ScriptO
             .withCommands(commands)
             .withTargetOS(os);
 
-        // Docker can create the working directory owned by a user other than the non-root image user (e.g. `groovy` on `groovy:jdk21`), breaking outputFiles - see #411.
+        // A non-root image user may not own the working directory, breaking outputFiles - see #411.
         TaskRunner<?> taskRunner = commandsWrapper.getTaskRunner();
         if (taskRunner instanceof Docker docker && docker.getUser() == null) {
             commandsWrapper = commandsWrapper.withTaskRunner(docker.toBuilder().user("root").build());

--- a/plugin-script-groovy/src/main/resources/doc/io.kestra.plugin.scripts.groovy.md
+++ b/plugin-script-groovy/src/main/resources/doc/io.kestra.plugin.scripts.groovy.md
@@ -1,11 +1,17 @@
 # How to use the Groovy plugin
 
-Execute Groovy code directly in the Kestra JVM — no container or task runner required.
+Execute Groovy code in the Kestra JVM, or run Groovy scripts and commands on a task runner.
 
 ## Tasks
 
-`Eval` runs inline Groovy code and is the primary task for general scripting. `Script` runs a Groovy script file. Both execute in-process on the Kestra worker with access to the full JVM classpath — no `containerImage` or `taskRunner` is needed.
+`Eval` runs inline Groovy code and is the primary task for general scripting. It executes in-process on the Kestra worker with access to the full JVM classpath — no `containerImage` or `taskRunner` is needed.
+
+`Script` runs an inline Groovy script and `Commands` runs Groovy commands against script files. Both execute on a task runner — Docker by default, using the `groovy` image.
 
 `FileTransform` processes Kestra internal storage files (Ion, Avro, JSON) record by record, transforming or filtering rows without writing intermediate files to disk. It is the right choice when you need lightweight row-level data transformation between tasks.
 
 Add Maven dependencies inline using Grape annotations: `@Grab('group:artifact:version')` at the top of your script resolves the dependency from Maven Central at runtime.
+
+## Container user
+
+The working directory Kestra mounts is not necessarily owned by the image's default user (`groovy`, uid 1000, on `groovy:jdk21`), so a non-root process cannot always write the files that `outputFiles` collects. On the Docker task runner, `Commands` therefore runs the container as `root` unless you set `taskRunner.user` explicitly; set it if you need the container to keep its own default user, and make sure that user can write to the working directory. `Script` always runs as `root` on Docker and ignores `taskRunner.user`.

--- a/plugin-script-groovy/src/test/java/io/kestra/plugin/scripts/groovy/CommandsTest.java
+++ b/plugin-script-groovy/src/test/java/io/kestra/plugin/scripts/groovy/CommandsTest.java
@@ -1,12 +1,19 @@
 package io.kestra.plugin.scripts.groovy;
 
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.jupiter.api.Test;
 
+import com.github.dockerjava.api.DockerClient;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.CharStreams;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.LogEntry;
@@ -15,13 +22,19 @@ import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
+import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.kestra.plugin.scripts.runner.docker.DockerService;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import reactor.core.publisher.Flux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
@@ -29,6 +42,9 @@ public class CommandsTest {
 
     @Inject
     RunContextFactory runContextFactory;
+
+    @Inject
+    StorageInterface storageInterface;
 
     @Inject
     @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
@@ -54,5 +70,109 @@ public class CommandsTest {
         TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("I love Kestra!"));
         receive.blockLast();
         assertThat(List.copyOf(logs).stream().anyMatch(log -> log.getMessage() != null && log.getMessage().contains("I love Kestra!")), is(true));
+    }
+
+    // The Docker runner can create the working directory owned by a user other than the container's
+    // default image user, so a `Commands` task running as that non-root user can't write its own
+    // outputFiles there (e.g. `groovy` on `groovy:jdk21`, see https://github.com/kestra-io/plugin-scripts/issues/411).
+    // The test image forces a non-root user whose uid never matches the current host user, so the
+    // reproduction doesn't depend on the host uid coincidentally matching the container's default user.
+    @Test
+    void outputFilesOnNonRootImage() throws Exception {
+        String nonRootImage = "kestra-test/groovy-non-root:" + UUID.randomUUID();
+
+        var groovyCommands = Commands.builder()
+            .id("groovy-commands-" + UUID.randomUUID())
+            .type(Commands.class.getName())
+            .allowWarning(true)
+            .containerImage(Property.ofValue(nonRootImage))
+            .outputFiles(Property.ofValue(List.of("out.txt")))
+            .commands(Property.ofValue(List.of(
+                "id",
+                "ls -ld .",
+                "groovy -e 'new File(\"out.txt\").text = \"hello\"'"
+            )))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, groovyCommands, ImmutableMap.of());
+
+        buildNonRootTestImage(runContext, nonRootImage);
+        try {
+            ScriptOutput run = groovyCommands.run(runContext);
+
+            assertThat(run.getExitCode(), is(0));
+            assertThat(run.getOutputFiles(), hasKey("out.txt"));
+
+            try (InputStream is = storageInterface.get(TenantService.MAIN_TENANT, null, run.getOutputFiles().get("out.txt"))) {
+                assertThat(CharStreams.toString(new InputStreamReader(is)), is("hello"));
+            }
+        } finally {
+            removeTestImage(runContext, nonRootImage);
+        }
+    }
+
+    // Regression test for the deprecated `docker` property path: `CommandsWrapper.getTaskRunner()` rebuilds
+    // the runner from `DockerOptions` on every call (via `Docker.from(...)`), so the root default must be
+    // applied in `injectDefaults`, not only on the `taskRunner` used by the modern `taskRunner` property.
+    @Test
+    void outputFilesOnNonRootImageLegacyDockerProperty() throws Exception {
+        String nonRootImage = "kestra-test/groovy-non-root-legacy:" + UUID.randomUUID();
+
+        var groovyCommands = Commands.builder()
+            .id("groovy-commands-" + UUID.randomUUID())
+            .type(Commands.class.getName())
+            .allowWarning(true)
+            .docker(DockerOptions.builder().image(nonRootImage).build())
+            .outputFiles(Property.ofValue(List.of("out.txt")))
+            .commands(Property.ofValue(List.of(
+                "id",
+                "ls -ld .",
+                "groovy -e 'new File(\"out.txt\").text = \"hello\"'"
+            )))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, groovyCommands, ImmutableMap.of());
+
+        buildNonRootTestImage(runContext, nonRootImage);
+        try {
+            ScriptOutput run = groovyCommands.run(runContext);
+
+            assertThat(run.getExitCode(), is(0));
+            assertThat(run.getOutputFiles(), hasKey("out.txt"));
+
+            try (InputStream is = storageInterface.get(TenantService.MAIN_TENANT, null, run.getOutputFiles().get("out.txt"))) {
+                assertThat(CharStreams.toString(new InputStreamReader(is)), is("hello"));
+            }
+        } finally {
+            removeTestImage(runContext, nonRootImage);
+        }
+    }
+
+    private void buildNonRootTestImage(RunContext runContext, String tag) throws Exception {
+        Path buildContext = Files.createTempDirectory("groovy-non-root-image");
+        Files.writeString(buildContext.resolve("Dockerfile"), """
+            FROM groovy:jdk21
+            USER root
+            RUN groupadd -g 5000 kestratest && useradd -u 5000 -g 5000 -m kestratest
+            USER kestratest
+            """);
+
+        try (DockerClient dockerClient = DockerService.client(runContext, null, null, null, null)) {
+            dockerClient.buildImageCmd(buildContext.resolve("Dockerfile").toFile())
+                .withTags(Set.of(tag))
+                .start()
+                .awaitImageId();
+        } finally {
+            Files.deleteIfExists(buildContext.resolve("Dockerfile"));
+            Files.deleteIfExists(buildContext);
+        }
+    }
+
+    private void removeTestImage(RunContext runContext, String tag) {
+        try (DockerClient dockerClient = DockerService.client(runContext, null, null, null, null)) {
+            dockerClient.removeImageCmd(tag).withForce(true).exec();
+        } catch (Exception ignored) {
+            // best-effort cleanup of the throwaway test image
+        }
     }
 }

--- a/plugin-script-groovy/src/test/java/io/kestra/plugin/scripts/groovy/CommandsTest.java
+++ b/plugin-script-groovy/src/test/java/io/kestra/plugin/scripts/groovy/CommandsTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +40,7 @@ import static org.hamcrest.Matchers.is;
 
 @KestraTest
 public class CommandsTest {
+    private static final long IMAGE_BUILD_TIMEOUT_MINUTES = 5;
 
     @Inject
     RunContextFactory runContextFactory;
@@ -72,11 +74,7 @@ public class CommandsTest {
         assertThat(List.copyOf(logs).stream().anyMatch(log -> log.getMessage() != null && log.getMessage().contains("I love Kestra!")), is(true));
     }
 
-    // The Docker runner can create the working directory owned by a user other than the container's
-    // default image user, so a `Commands` task running as that non-root user can't write its own
-    // outputFiles there (e.g. `groovy` on `groovy:jdk21`, see https://github.com/kestra-io/plugin-scripts/issues/411).
-    // The test image forces a non-root user whose uid never matches the current host user, so the
-    // reproduction doesn't depend on the host uid coincidentally matching the container's default user.
+    // A non-root image user may not own the working directory, breaking outputFiles - see https://github.com/kestra-io/plugin-scripts/issues/411.
     @Test
     void outputFilesOnNonRootImage() throws Exception {
         String nonRootImage = "kestra-test/groovy-non-root:" + UUID.randomUUID();
@@ -111,9 +109,7 @@ public class CommandsTest {
         }
     }
 
-    // Regression test for the deprecated `docker` property path: `CommandsWrapper.getTaskRunner()` rebuilds
-    // the runner from `DockerOptions` on every call (via `Docker.from(...)`), so the root default must be
-    // applied in `injectDefaults`, not only on the `taskRunner` used by the modern `taskRunner` property.
+    // Same regression on the deprecated `docker` property path, which rebuilds the runner from `DockerOptions`.
     @Test
     void outputFilesOnNonRootImageLegacyDockerProperty() throws Exception {
         String nonRootImage = "kestra-test/groovy-non-root-legacy:" + UUID.randomUUID();
@@ -161,7 +157,7 @@ public class CommandsTest {
             dockerClient.buildImageCmd(buildContext.resolve("Dockerfile").toFile())
                 .withTags(Set.of(tag))
                 .start()
-                .awaitImageId();
+                .awaitImageId(IMAGE_BUILD_TIMEOUT_MINUTES, TimeUnit.MINUTES);
         } finally {
             Files.deleteIfExists(buildContext.resolve("Dockerfile"));
             Files.deleteIfExists(buildContext);


### PR DESCRIPTION
Closes #411

## Problem

On the Docker task runner, the working directory can end up owned by a user other than the container image's default user. On a non-root image such as `groovy:jdk21` (`USER groovy`, uid 1000), a `groovy.Commands` task cannot write into its own working directory, so `outputFiles` fails with `FileNotFoundException: out.txt (Permission denied)` and captures 0 files.

`groovy.Script` already forces `user("root")` on its Docker runner and is therefore unaffected — `Commands` had no equivalent, which is the inconsistency reported in the issue.

## Fix

Default the Docker runner's `user` to `root` when the user has not configured one explicitly, on **both** config paths:

- the modern `taskRunner:` path, in `Commands.run()`;
- the deprecated `docker:` property path, in `Commands.injectDefaults()` — necessary because `CommandsWrapper.getTaskRunner()` rebuilds the runner from `dockerOptions` on every call and discards any `withTaskRunner(...)` override.

Unlike `Script` (which replaces the task runner wholesale and drops any custom Docker options), this preserves every other option the user configured — volumes, memory, cpu, pull policy, credentials — and never overrides an explicitly set `user`.

## Scope

Checked the other modules with a non-root-looking default image; both `oven/bun` and `denoland/deno` create a non-root account but never `USER`-switch to it, so they still run as root (`docker run --rm oven/bun id` → `uid=0(root)`, same for `denoland/deno`). Groovy is the only affected module.

## Tests

`plugin-script-groovy/src/test/java/io/kestra/plugin/scripts/groovy/CommandsTest.java`:

- `outputFilesOnNonRootImage()` — modern `taskRunner:` path
- `outputFilesOnNonRootImageLegacyDockerProperty()` — deprecated `docker:` path

Both build a throwaway image `FROM groovy:jdk21` with a user at uid 5000, so the reproduction does not depend on the host uid coincidentally matching the image's default uid (with `groovy:jdk21`'s own uid 1000 the bug reproduces only on some hosts/engines). Verified TDD-style: without the fix both fail with `uid=5000` and `Permission denied`; with it both log `uid=0(root)` and capture `out.txt`.

`./gradlew :plugin-script-groovy:test` — BUILD SUCCESSFUL, 3 tests, 0 failures.

## Note for reviewers

Running containers as root by default is a real behavior change for anyone relying on the image's non-root user. It matches what `groovy.Script` has always done, and setting `taskRunner.user` explicitly opts out. Happy to instead scope it behind something more explicit if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)