### PR TITLE
fix(r): de-flake ScriptTest and stop building lubridate from source

### DIFF
--- a/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/ScriptTest.java
+++ b/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/ScriptTest.java
@@ -33,17 +33,20 @@ class ScriptTest {
 
     @Test
     void script() throws Exception {
-        // The dates are written to an output file rather than asserted on the task run logs: log
-        // emission is asynchronous, and the `install.packages("lubridate")` before-command builds
-        // lubridate and its dependencies from source, flooding the log queue with thousands of
-        // lines. The script's own output lands behind that backlog and made this test flaky.
+        // lubridate is installed from Debian's prebuilt `r-cran-lubridate` package rather than with
+        // `install.packages()`: the `r-base` image has no CRAN binary for its R version, so
+        // install.packages() builds lubridate and its dependencies from source (~90s and thousands
+        // of log lines). The dates are also written to an output file rather than asserted on the
+        // task run logs, as log emission is asynchronous and the script's own output could land
+        // behind that backlog, which made this test flaky.
         Script rScript = Script.builder()
             .id("r-script-" + UUID.randomUUID())
             .type(Script.class.getName())
             .beforeCommands(
                 Property.ofValue(
                     List.of(
-                        "Rscript -e 'install.packages(\"lubridate\")'"
+                        "apt-get update -qq",
+                        "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq r-cran-lubridate"
                     )
                 )
             )
@@ -52,14 +55,13 @@ class ScriptTest {
                 Property.ofValue(
                     """
                         library(lubridate)
-                        writeLines(
-                            c(
-                                as.character(ymd("20100604")),
-                                as.character(mdy("06-04-2011")),
-                                as.character(dmy("04/06/2012"))
-                            ),
-                            "dates.txt"
-                        )"""
+                        dates <- c(
+                            as.character(ymd("20100604")),
+                            as.character(mdy("06-04-2011")),
+                            as.character(dmy("04/06/2012"))
+                        )
+                        writeLines(dates)
+                        writeLines(dates, "dates.txt")"""
                 )
             )
             .build();

--- a/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/ScriptTest.java
+++ b/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/ScriptTest.java
@@ -33,12 +33,9 @@ class ScriptTest {
 
     @Test
     void script() throws Exception {
-        // lubridate is installed from Debian's prebuilt `r-cran-lubridate` package rather than with
-        // `install.packages()`: the `r-base` image has no CRAN binary for its R version, so
-        // install.packages() builds lubridate and its dependencies from source (~90s and thousands
-        // of log lines). The dates are also written to an output file rather than asserted on the
-        // task run logs, as log emission is asynchronous and the script's own output could land
-        // behind that backlog, which made this test flaky.
+        // lubridate comes from Debian's prebuilt package (no CRAN binary for this R version, so
+        // install.packages() would build from source) and the dates are asserted on an output file
+        // rather than on the asynchronously-emitted task run logs.
         Script rScript = Script.builder()
             .id("r-script-" + UUID.randomUUID())
             .type(Script.class.getName())
@@ -74,7 +71,7 @@ class ScriptTest {
         assertThat(run.getStdErrLineCount(), greaterThan(1));
 
         assertThat(run.getOutputFiles().get("dates.txt").toString(), startsWith("kestra://"));
-        String dates = new String(
+        var dates = new String(
             storageInterface.get(TenantService.MAIN_TENANT, null, run.getOutputFiles().get("dates.txt")).readAllBytes()
         );
         assertThat(dates.lines().toList(), is(List.of("2010-06-04", "2011-06-04", "2012-06-04")));

--- a/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/ScriptTest.java
+++ b/plugin-script-r/src/test/java/io/kestra/plugin/scripts/r/ScriptTest.java
@@ -2,32 +2,26 @@ package io.kestra.plugin.scripts.r;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 
 import io.kestra.core.junit.annotations.KestraTest;
-import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.queues.QueueFactoryInterface;
-import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
-import io.kestra.core.utils.Await;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import reactor.core.publisher.Flux;
-
-import java.time.Duration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 @KestraTest
 class ScriptTest {
@@ -35,14 +29,14 @@ class ScriptTest {
     RunContextFactory runContextFactory;
 
     @Inject
-    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
-    private QueueInterface<LogEntry> logQueue;
+    StorageInterface storageInterface;
 
     @Test
     void script() throws Exception {
-        List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
-
+        // The dates are written to an output file rather than asserted on the task run logs: log
+        // emission is asynchronous, and the `install.packages("lubridate")` before-command builds
+        // lubridate and its dependencies from source, flooding the log queue with thousands of
+        // lines. The script's own output lands behind that backlog and made this test flaky.
         Script rScript = Script.builder()
             .id("r-script-" + UUID.randomUUID())
             .type(Script.class.getName())
@@ -53,13 +47,19 @@ class ScriptTest {
                     )
                 )
             )
+            .outputFiles(Property.ofValue(List.of("dates.txt")))
             .script(
                 Property.ofValue(
                     """
                         library(lubridate)
-                        ymd("20100604");
-                        mdy("06-04-2011");
-                        dmy("04/06/2012")"""
+                        writeLines(
+                            c(
+                                as.character(ymd("20100604")),
+                                as.character(mdy("06-04-2011")),
+                                as.character(dmy("04/06/2012"))
+                            ),
+                            "dates.txt"
+                        )"""
                 )
             )
             .build();
@@ -71,14 +71,10 @@ class ScriptTest {
         assertThat(run.getStdOutLineCount(), greaterThan(1));
         assertThat(run.getStdErrLineCount(), greaterThan(1));
 
-        Await.until(() ->
-            logs.stream().anyMatch(log -> log.getMessage() != null && log.getMessage().contains("2010-06-04")) &&
-            logs.stream().anyMatch(log -> log.getMessage() != null && log.getMessage().contains("2011-06-04")) &&
-            logs.stream().anyMatch(log -> log.getMessage() != null && log.getMessage().contains("2012-06-04")),
-            Duration.ofMillis(100), Duration.ofSeconds(30)
+        assertThat(run.getOutputFiles().get("dates.txt").toString(), startsWith("kestra://"));
+        String dates = new String(
+            storageInterface.get(TenantService.MAIN_TENANT, null, run.getOutputFiles().get("dates.txt")).readAllBytes()
         );
-        receive.blockLast();
-        assertThat(List.copyOf(logs).stream().filter(logEntry -> logEntry.getMessage() != null && logEntry.getMessage().contains("2010-06-04")).count(), is(1L));
-        assertThat(List.copyOf(logs).stream().filter(logEntry -> logEntry.getMessage() != null && logEntry.getMessage().contains("2011-06-04")).count(), is(1L));
+        assertThat(dates.lines().toList(), is(List.of("2010-06-04", "2011-06-04", "2012-06-04")));
     }
 }


### PR DESCRIPTION
## What

Two commits, both on `plugin-script-r`'s `ScriptTest`:

1. **`fix(r)`** — the test no longer scrapes the `WORKERTASKLOG` queue for the dates printed by the R script. The script writes them to an output file, and the test asserts on that file's content read back from internal storage.
2. **`perf(r)`** — lubridate is installed from Debian's prebuilt `r-cran-lubridate` package instead of with `install.packages()`.

## Why

The nightly `main` run [#34081882896](https://github.com/kestra-io/plugin-scripts/actions/runs/34081882896/job/101618584465) failed with:

```
java.util.concurrent.TimeoutException: Await failed to terminate within PT30S.
  at io.kestra.core.utils.Await.until(Await.java:47)
  at io.kestra.plugin.scripts.r.ScriptTest.script(ScriptTest.java:74)
```

The R task itself was fine — exit code 0, and the container stream shows the expected output right before the timeout:

```
* DONE (lubridate)
[1] "2010-06-04"
[1] "2011-06-04"
[1] "2012-06-04"
```

What failed is the `Await` on the log queue. Log emission is explicitly asynchronous (`LogEntryEmitter.emits`: *"the log entry is not guaranteed to be emitted immediately"*), and this test flooded it: `install.packages("lubridate")` found no CRAN binary for R 4.6.1 in the `r-base` image, so it built `cpp11`, `generics`, `timechange` and `lubridate` from source — ~90s and a few thousand log lines. The script's own three lines landed behind that backlog, so on a loaded runner they could arrive after the 30s window. Timing confirms it: last stdout line at `04:09:13`, timeout at `04:09:44`.

This test had already been patched twice for the same flakiness (b5d9521, 07f643b), each time by extending the wait. So this PR removes both halves of the race instead of widening the window again:

- Asserting on the output file is synchronous, and checks the exact three values in order rather than their presence somewhere in the logs.
- The Debian package removes the source build, which was both the log flood and the reason this module took ~2.5 minutes.

The script still writes its dates to stdout as well as to the file, so the `stdOutLineCount`/`stdErrLineCount` assertions stay meaningful now that the before-commands are quiet.

## Test

`./gradlew :plugin-script-r:test --tests '*r.ScriptTest*'` passes locally, and drops from **4m31s to 13s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)