### PR TITLE
fix(python): give the all_python sanity check a 5-minute timeout

### DIFF
--- a/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/RunnerTest.java
+++ b/plugin-script-python/src/test/java/io/kestra/plugin/scripts/python/RunnerTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 @KestraTest(startRunner = true)
 class RunnerTest {
     @Test
-    @ExecuteFlow("sanity-checks/all_python.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_python.yaml", timeout = "PT5M")
     void all_python(Execution execution) {
         assertThat(execution.getTaskRunList(), hasSize(9));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));


### PR DESCRIPTION
## What

Adds `timeout = "PT5M"` to `RunnerTest.all_python`, matching the go, deno, php, bun and dotnet sanity checks.

## Why

CI went red on `main` in [run 34103015639](https://github.com/kestra-io/plugin-scripts/actions/runs/34103015639) with a harness timeout, not an assertion failure:

```
Failed to resolve parameter [Execution arg0] in method
  [void io.kestra.plugin.scripts.python.RunnerTest.all_python(Execution)]:
Execution 5XFdbRli9DPS3MRvWa35Mx is currently at the status RUNNING which is not the awaited one
  at io.kestra.core.runners.TestRunnerUtils.awaitExecution(TestRunnerUtils.java:270)
```

The test ran 1m 01s against the 60s `TestRunnerUtils.DEFAULT_MAX_WAIT_DURATION`. Every task up to the cutoff had `SUCCESS` — the flow was simply still working through task seven of nine (`python_script_outputs`) when the harness gave up.

`all_python.yaml` runs nine sequential tasks: four `pip install kestra` in a fresh container, two `ghcr.io/kestra-io/pydata:latest` pulls, and two process-runner tasks that bootstrap `uv` (`Unable to detect an installed version of 'uv'. Attempting to install...`). It has been sitting at 85–90% of the budget for days:

| Run | When | Duration |
| --- | --- | --- |
| 33835569605 | Sep 4 | 50.9s ✅ |
| 34081882896 | Sep 7 04:06 | 53.8s ✅ |
| 34103015639 | Sep 7 09:04 | >60s ❌ |

The runs in between show `:plugin-script-python:test FROM-CACHE`, which is why this looks like a sudden break — the task had not actually re-executed since Sep 4.

## Scope

Python only. It is the one module still on the default timeout that is anywhere near the limit — `perl` 29.8s, `groovy` 33.3s, `lua` 11.3s, `nashorn` 7.5s, `shell` 6.0s in the same run. (`all_go` also hit 1m 00s there but passed, because it already declares `PT5M`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)